### PR TITLE
31175 - D5 :: 3PS :: Set custom icon for module extension example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ This modules is converted from Divi 4 to Divi 5. It will help you to understand 
 ## Divi 4 Modules
 You can find the Divi 4 modules in the `divi-4/modules` folder. You can use these modules as a reference for your migration process. Currently, we have converted the `Divi4Module` module from Divi 4 to Divi 5 and `Divi4OnlyModule` module is only for Divi 4.
 
+## Module Conversion
+You can find the module conversion process in the `src/components/d4-module` folder. You can use this process for your migration process. Also, maybe you need to convert the module attributes to new format. Most of will be done automatically. But some conversion need to be declare in the `src/module-exceptions.ts` file.
+
+## Module Icons
+You can find the module icons in the `src/icons` folder. You can use these icons for module icon. You can also add your own icons in this folder.
+
 ## Storybook
 All modules have storybook examples. You will find all story declarations in the `stories` folder. The configuration for the storybook contains the `.storybook` folder. You must need to add a `.env` file to start the storybook. You can see the `.env.example` file for reference. You need to add only `STORYBOOK_SITE_URL` variable with the WordPress site URL.
 
@@ -98,29 +104,35 @@ d5-extension-example-modules
 │   └── Modules.php
 ├── src
 │   ├── components
-│   │   ├── module-name
-│   │   │   ├── __mock-data__
-│   │   │   │   └── attrs.ts
-│   │   │   ├── __tests__
-│   │   │   │   ├── __snapshots__
-│   │   │   │   │   └── edit.tsx.snap
-│   │   │   │   └── edit.tsx
-│   │   │   ├── stories
-│   │   │   │   └── edit.stories.tsx
-│   │   │   ├── constants.ts
-│   │   │   ├── custom-css.ts
-│   │   │   ├── edit.tsx
-│   │   │   ├── index.ts
-│   │   │   ├── module.json
-│   │   │   ├── module.scss
-│   │   │   ├── placeholder-content.ts
-│   │   │   ├── settings-advanced.tsx
-│   │   │   ├── settings-content.tsx
-│   │   │   ├── settings-design.tsx
-│   │   │   ├── style.scss
-│   │   │   ├── styles.tsx
-│   │   │   └── types.ts
-│   └── index.ts
+│   │   └── module-name
+│   │       ├── __mock-data__
+│   │       │   └── attrs.ts
+│   │       ├── __tests__
+│   │       │   ├── __snapshots__
+│   │       │   │   └── edit.tsx.snap
+│   │       │   └── edit.tsx
+│   │       ├── stories
+│   │       │   └── edit.stories.tsx
+│   │       ├── constants.ts
+│   │       ├── custom-css.ts
+│   │       ├── edit.tsx
+│   │       ├── index.ts
+│   │       ├── module.json
+│   │       ├── module.scss
+│   │       ├── placeholder-content.ts
+│   │       ├── settings-advanced.tsx
+│   │       ├── settings-content.tsx
+│   │       ├── settings-design.tsx
+│   │       ├── style.scss
+│   │       ├── styles.tsx
+│   │       └── types.ts
+|   ├── icons
+|   |   ├── icon-name
+|   |   |   └── index.tsx
+│   │   └── index.ts
+│   ├── index.ts
+│   ├── module-exceptions.ts
+│   └── module-icons.ts
 ├── storybook-assets
 │   └── mockServiceWorker.js
 ├── test-config

--- a/d5-extension-example-modules.php
+++ b/d5-extension-example-modules.php
@@ -29,32 +29,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Direct access forbidden.' );
 }
 
-define( 'D5_MODULE_EXTENSION_EXAMPLE_PATH', plugin_dir_path( __FILE__ ) );
-define( 'D5_MODULE_EXTENSION_EXAMPLE_JSON_PATH', D5_MODULE_EXTENSION_EXAMPLE_PATH . 'modules-json/' );
+define( 'D5_EXTENSION_EXAMPLE_MODULES_PATH', plugin_dir_path( __FILE__ ) );
+define( 'D5_EXTENSION_EXAMPLE_MODULES_JSON_PATH', D5_EXTENSION_EXAMPLE_MODULES_PATH . 'modules-json/' );
 
 /**
  * Requires Autoloader.
  */
-require D5_MODULE_EXTENSION_EXAMPLE_PATH . 'vendor/autoload.php';
-require D5_MODULE_EXTENSION_EXAMPLE_PATH . 'modules/Modules.php';
+require D5_EXTENSION_EXAMPLE_MODULES_PATH . 'vendor/autoload.php';
+require D5_EXTENSION_EXAMPLE_MODULES_PATH . 'modules/Modules.php';
 
 /**
  * Register all Divi 4 modules.
  *
  * @since ??
  */
-function d5_module_extension_example_initialize_d4_modules() {
-	require_once D5_MODULE_EXTENSION_EXAMPLE_PATH . 'divi-4/modules/Divi4Module/Divi4Module.php';
-	require_once D5_MODULE_EXTENSION_EXAMPLE_PATH . 'divi-4/modules/Divi4OnlyModule/Divi4OnlyModule.php';
+function d5_extension_example_module_initialize_d4_modules() {
+	require_once D5_EXTENSION_EXAMPLE_MODULES_PATH . 'divi-4/modules/Divi4Module/Divi4Module.php';
+	require_once D5_EXTENSION_EXAMPLE_MODULES_PATH . 'divi-4/modules/Divi4OnlyModule/Divi4OnlyModule.php';
 }
-add_action( 'et_builder_ready', 'd5_module_extension_example_initialize_d4_modules' );
+add_action( 'et_builder_ready', 'd5_extension_example_module_initialize_d4_modules' );
 
 /**
  * Enqueue style and scripts of Module Extension Example for Visual Builder.
  *
  * @since ??
  */
-function d5_module_extension_example_enqueue_vb_scripts() {
+function d5_extension_example_module_enqueue_vb_scripts() {
 	if ( et_builder_d5_enabled() && et_core_is_fb_enabled() ) {
 		$plugin_dir_url = plugin_dir_url( __FILE__ );
 
@@ -71,15 +71,15 @@ function d5_module_extension_example_enqueue_vb_scripts() {
 		wp_enqueue_style( 'd5-extension-example-modules-builder-vb-bundle-style', "{$plugin_dir_url}styles/vb-bundle.css", array(), '1.0.0' );
 	}
 }
-add_action( 'et_vb_assets_before_enqueue_packages', 'd5_module_extension_example_enqueue_vb_scripts' );
+add_action( 'et_vb_assets_before_enqueue_packages', 'd5_extension_example_module_enqueue_vb_scripts' );
 
 /**
  * Enqueue style and scripts of Module Extension Example
  *
  * @since ??
  */
-function d5_module_extension_example_enqueue_frontend_scripts() {
+function d5_extension_example_module_enqueue_frontend_scripts() {
 	$plugin_dir_url = plugin_dir_url( __FILE__ );
 	wp_enqueue_style( 'd5-extension-example-modules-builder-bundle-style', "{$plugin_dir_url}styles/bundle.css", array(), '1.0.0' );
 }
-add_action( 'wp_enqueue_scripts', 'd5_module_extension_example_enqueue_frontend_scripts' );
+add_action( 'wp_enqueue_scripts', 'd5_extension_example_module_enqueue_frontend_scripts' );

--- a/modules/ChildModule/ChildModule.php
+++ b/modules/ChildModule/ChildModule.php
@@ -34,7 +34,7 @@ class ChildModule implements DependencyInterface {
 	 * @return void
 	 */
 	public function load() {
-		$module_json_folder_path = D5_MODULE_EXTENSION_EXAMPLE_JSON_PATH . 'child-module/';
+		$module_json_folder_path = D5_EXTENSION_EXAMPLE_MODULES_JSON_PATH . 'child-module/';
 
 		add_action(
 			'init',

--- a/modules/D4Module/D4Module.php
+++ b/modules/D4Module/D4Module.php
@@ -34,7 +34,7 @@ class D4Module implements DependencyInterface {
 	 * @return void
 	 */
 	public function load() {
-		$module_json_folder_path = D5_MODULE_EXTENSION_EXAMPLE_JSON_PATH . 'd4-module/';
+		$module_json_folder_path = D5_EXTENSION_EXAMPLE_MODULES_JSON_PATH . 'd4-module/';
 
 		add_action(
 			'init',

--- a/modules/DynamicModule/DynamicModule.php
+++ b/modules/DynamicModule/DynamicModule.php
@@ -34,7 +34,7 @@ class DynamicModule implements DependencyInterface {
 	 * @return void
 	 */
 	public function load() {
-		$module_json_folder_path = D5_MODULE_EXTENSION_EXAMPLE_JSON_PATH . 'dynamic-module/';
+		$module_json_folder_path = D5_EXTENSION_EXAMPLE_MODULES_JSON_PATH . 'dynamic-module/';
 
 		add_action(
 			'init',

--- a/modules/ParentModule/ParentModule.php
+++ b/modules/ParentModule/ParentModule.php
@@ -35,7 +35,7 @@ class ParentModule implements DependencyInterface {
 	 * @return void
 	 */
 	public function load() {
-		$module_json_folder_path = D5_MODULE_EXTENSION_EXAMPLE_JSON_PATH . 'parent-module/';
+		$module_json_folder_path = D5_EXTENSION_EXAMPLE_MODULES_JSON_PATH . 'parent-module/';
 
 		add_action(
 			'init',

--- a/modules/StaticModule/StaticModule.php
+++ b/modules/StaticModule/StaticModule.php
@@ -34,7 +34,7 @@ class StaticModule implements DependencyInterface {
 	 * @return void
 	 */
 	public function load() {
-		$module_json_folder_path = D5_MODULE_EXTENSION_EXAMPLE_JSON_PATH . 'static-module/';
+		$module_json_folder_path = D5_EXTENSION_EXAMPLE_MODULES_JSON_PATH . 'static-module/';
 
 		add_action(
 			'init',

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/divi__module": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__module",
     "@types/divi__module-library": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__module-library",
     "@types/divi__module-utils": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__module-utils",
+    "@types/divi__script-library": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__script-library",
     "@types/divi__serialized-post": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__serialized-post",
     "@types/divi__settings": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__settings",
     "@types/enzyme": "^3.10.12",

--- a/src/components/d4-module/module.json
+++ b/src/components/d4-module/module.json
@@ -3,6 +3,7 @@
     "d4Shortcode": "d4_module",
     "title": "Divi 4 Module",
     "titles": "Divi 4 Modules",
+    "moduleIcon": "example/module-d4",
     "category": "module",
     "attributes": {
         "text": {

--- a/src/components/dynamic-module/module.json
+++ b/src/components/dynamic-module/module.json
@@ -3,6 +3,7 @@
     "d4Shortcode": "",
     "title": "Dynamic Module",
     "titles": "Dynamic Modules",
+    "moduleIcon": "example/module-dynamic",
     "category": "module",
     "attributes": {
         "numberOfPosts": {

--- a/src/components/parent-module/module.json
+++ b/src/components/parent-module/module.json
@@ -3,6 +3,7 @@
     "d4Shortcode": "",
     "title": "Parent Module",
     "titles": "Parent Modules",
+    "moduleIcon": "example/module-parent",
     "category": "module",
     "attributes": {
         "icon": {

--- a/src/components/static-module/edit.tsx
+++ b/src/components/static-module/edit.tsx
@@ -35,6 +35,7 @@ const StaticModuleEdit = (props: StaticModuleEditProps): ReactElement => {
     attrs,
   });
 
+  // Get module attributes.
   const HeadingLevel            = moduleAttrs?.titleFont?.font?.desktop?.value?.headingLevel;
   const title                   = moduleAttrs?.title?.desktop?.value;
   const content                 = moduleAttrs?.content?.desktop?.value;

--- a/src/components/static-module/module.json
+++ b/src/components/static-module/module.json
@@ -3,6 +3,7 @@
     "d4Shortcode": "",
     "title": "Static Module",
     "titles": "Static Modules",
+    "moduleIcon": "example/module-static",
     "category": "module",
     "attributes": {
         "text": {

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,0 +1,4 @@
+export * as moduleParent from './module-parent';
+export * as moduleStatic from './module-static';
+export * as moduleD4 from './module-d4';
+export * as moduleDynamic from './module-dynamic';

--- a/src/icons/module-d4/index.tsx
+++ b/src/icons/module-d4/index.tsx
@@ -1,0 +1,8 @@
+import React, { ReactElement } from 'react';
+
+// Icon data.
+export const name      = 'example/module-d4'; // Unique name.
+export const viewBox   = '0 96 960 960'; // You will need to adjust this to match your SVG.
+export const component = (): ReactElement => (
+  <path d="M480.276 1006q-88.916 0-167.743-33.104-78.828-33.103-137.577-91.852-58.749-58.749-91.852-137.535Q50 664.723 50 575.542q0-89.438 33.162-167.491 33.163-78.053 92.175-136.942 59.011-58.889 137.533-91.999Q391.393 146 480.458 146q89.428 0 167.518 33.093T784.94 271.06q58.874 58.874 91.967 137.215Q910 486.615 910 575.808q0 89.192-33.11 167.518-33.11 78.326-91.999 137.337-58.889 59.012-137.167 92.174Q569.447 1006 480.276 1006ZM523 774h97V378h-97v161h-86V378h-97v259h183v137Z"/>
+); // Your SVG path. without the svg tag.

--- a/src/icons/module-dynamic/index.tsx
+++ b/src/icons/module-dynamic/index.tsx
@@ -1,0 +1,8 @@
+import React, { ReactElement } from 'react';
+
+// Icon data.
+export const name      = 'example/module-dynamic'; // Unique name.
+export const viewBox   = '0 96 960 960'; // You will need to adjust this to match your SVG.
+export const component = (): ReactElement => (
+  <path d="m552 240-36 312h192L415 912h-21l48-264H282l248-408h22Z"/>
+); // Your SVG path. without the svg tag.

--- a/src/icons/module-parent/index.tsx
+++ b/src/icons/module-parent/index.tsx
@@ -1,0 +1,8 @@
+import React, { ReactElement } from 'react';
+
+// Icon data.
+export const name      = 'example/module-parent'; // Unique name.
+export const viewBox   = '0 96 960 960';  // You will need to adjust this to match your SVG.
+export const component = (): ReactElement => (
+  <path d="M238 879 62 704l91-90 84 85 170-171 91 91-260 260Zm0-312L62 392l91-90 85 85 169-171 91 91-260 260Zm291 229V668h369v128H529Zm0-312V356h369v128H529Z"/>
+); // Your SVG path. without the svg tag.

--- a/src/icons/module-static/index.tsx
+++ b/src/icons/module-static/index.tsx
@@ -1,0 +1,8 @@
+import React, { ReactElement } from 'react';
+
+// Icon data.
+export const name      = 'example/module-static'; // Unique name.
+export const viewBox   = '0 96 960 960'; // You will need to adjust this to match your SVG.
+export const component = (): ReactElement => (
+  <path d="M114 838V710h491v128H114Zm0-198V512h733v128H114Zm0-198V314h733v128H114Z"/>
+); // Your SVG path. without the svg tag.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { omit } from 'lodash';
-import { addAction, addFilter } from '@wordpress/hooks';
+import { addAction } from '@wordpress/hooks';
 import { registerModule } from '@divi/module-library';
 import { dynamicModule } from './components/dynamic-module';
 import { staticModule } from './components/static-module';
@@ -8,7 +8,9 @@ import { parentModule } from './components/parent-module';
 import { d4Module } from './components/d4-module';
 
 import './module-exceptions';
+import './module-icons';
 
+// Register modules.
 addAction('moduleLibrary.registerModuleLibraryStore.after', 'extensionExample', () => {
   registerModule(staticModule.metadata, omit(staticModule, 'metadata'));
   registerModule(dynamicModule.metadata, omit(dynamicModule, 'metadata'));

--- a/src/module-exceptions.ts
+++ b/src/module-exceptions.ts
@@ -1,10 +1,11 @@
 import { addFilter } from '@wordpress/hooks';
 
-addFilter('et_vb_module_exceptions_attr_map', 'd5-extension-example-modules', (moduleExceptions) => {
+// Add module exceptions to the conversion attributes map.
+addFilter('conversion.attrs.map.moduleExceptions', 'extensionExample', (moduleExceptions) => {
   return {
-      ...moduleExceptions,
+      ...moduleExceptions, // This is important. Without this, all other exceptions will be overwritten.
       'example/d4-module': {
-        header_level: 'titleFont.font.*.headingLevel',
+        header_level: 'titleFont.font.*.headingLevel', // This is a custom attribute. By default it will be converted to `headerLevel.*`. But we want to convert it to `titleFont.font.*.headingLevel`.
       },
   };
 });

--- a/src/module-icons.ts
+++ b/src/module-icons.ts
@@ -1,0 +1,18 @@
+import { addFilter } from '@wordpress/hooks';
+import {
+  moduleD4,
+  moduleDynamic,
+  moduleParent,
+  moduleStatic,
+} from './icons';
+
+// Add module icons to the icon library.
+addFilter('iconLibrary.icon.map', 'extensionExample', (icons) => {
+  return {
+    ...icons, // This is important. Without this, all other icons will be overwritten.
+    [moduleParent.name]:  moduleParent,
+    [moduleStatic.name]:  moduleStatic,
+    [moduleDynamic.name]: moduleDynamic,
+    [moduleD4.name]:      moduleD4,
+  };
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4604,6 +4604,12 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@types/divi__script-library@link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__script-library::locator=d5-extension-example-modules%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@types/divi__script-library@link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__script-library::locator=d5-extension-example-modules%40workspace%3A."
+  languageName: node
+  linkType: soft
+
 "@types/divi__serialized-post@link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__serialized-post::locator=d5-extension-example-modules%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "@types/divi__serialized-post@link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__serialized-post::locator=d5-extension-example-modules%40workspace%3A."
@@ -9124,6 +9130,7 @@ __metadata:
     "@types/divi__module": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__module"
     "@types/divi__module-library": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__module-library"
     "@types/divi__module-utils": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__module-utils"
+    "@types/divi__script-library": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__script-library"
     "@types/divi__serialized-post": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__serialized-post"
     "@types/divi__settings": "link:../../themes/Divi/includes/builder-5/visual-builder/packages/types-divi__settings"
     "@types/enzyme": ^3.10.12


### PR DESCRIPTION
### Summary
This PR will add the custom icons for modules and some bug fixing.

Fixes: https://github.com/elegantthemes/Divi/issues/31175

Note: You must need to switch to `31175-custom-icon-for-3ps` branch in `builder-5` and run `yarn start`.