### PR TITLE
D5 :: Fatal Error :: Fix fatal error due to missing file in Parent Module

### DIFF
--- a/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
+++ b/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
@@ -15,13 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 use ET\Builder\FrontEnd\Module\Style;
 use ET\Builder\Packages\Module\Layout\Components\StyleCommon\CommonStyle;
 use ET\Builder\Packages\Module\Options\Css\CssStyle;
-use ET\Builder\Packages\ModuleLibrary\Portfolio\PortfolioModuleTraits\StyleDeclarationTrait;
 use MEE\Modules\ChildModule\ChildModule;
 
 trait ModuleStylesTrait {
 
 	use CustomCssTrait;
-	use StyleDeclarationTrait;
 
 	/**
 	 * Child Module's style components.


### PR DESCRIPTION
# The Issue

## Issue Reference

Fixes: https://github.com/elegantthemes/Divi/issues/40383

## What the issue is

When we have Divi Extension Example Modules activated, there is PHP fatal error in the FE.

## Replicating issue
- Install and activate this plugin: [d5-extension-example-modules.zip](https://github.com/user-attachments/files/17458210/d5-extension-example-modules.zip).
- Just check the FE page and you will get the error. 

## Where does the issue come from

After this commit merged: https://github.com/elegantthemes/submodule-builder-5/commit/34f122332eb758ce1f1621ec41f3bab6fe026880.

## When the issue start to happen

After public alpha release.

## Who to contact regarding the issue

@nadim1992 

## Why the issue happened

The issue happened because `PortfolioModuleTraits/StyleDeclarationTrait.php` file is missing. This file is being used by `ParentModuleTrait/ModuleStylesTrait.php` of Parent Module of Divi Extension Example Modules plugin. The reason why the file is missing because we refactored the traits usage in D5 and used class methods based approach. You can see the details in this commit: https://github.com/elegantthemes/submodule-builder-5/commit/34f122332eb758ce1f1621ec41f3bab6fe026880. This caused the `StyleDeclarationTrait` was removed and all methods inside were moved to `PortfolioModule` class.

# The Pull Request

## How this pull request fixes the issue

To fix this issue we can simply just remove it because this trait is never being used in Parent Module style. So, we can simply remove the code to fix the fatal error.

## Possible alternate solution

N/A

## How the PR was verified

No longer error after the fix:

![No Error](https://github.com/user-attachments/assets/9dfd1bb7-314e-4671-a2af-b3504b51c437)

## Testing this PR

- Install and activate this updated plugin: [d5-extension-example-modules.zip](https://github.com/user-attachments/files/17458515/d5-extension-example-modules.zip). Or you can checkout to this PR branch and use it for testing.
- Just check the FE page and you will no longer get the error. 

## Changelog copy

Fixed fatal error due to missing Portfolio style declaration trait file after Public Alpha release.

## Affected areas

* FE
* Divi Extension Example Modules
