### PR TITLE
D5 :: Module Styles :: Add example of style output value format in FE module styles

### DIFF
--- a/modules/ChildModule/ChildModuleTrait/ModuleStylesTrait.php
+++ b/modules/ChildModule/ChildModuleTrait/ModuleStylesTrait.php
@@ -128,6 +128,22 @@ trait ModuleStylesTrait {
 							'property' => 'font-size',
 						]
 					),
+
+					// ATTENTION: The code is intentionally added and commented in FE only as an example of expected value format.
+					// If you have custom style processing, the style output should be passed as an `array` of style declarations
+					// to the `styles` property of the `Style::add` method. For example:
+					// [
+					// 	[
+					// 		'atRules'     => false,
+					// 		'selector'    => $icon_selector,
+					// 		'declaration' => 'color: red;'
+					// 	],
+					// 	[
+					// 		'atRules'     => '@media only screen and (max-width: 767px)',
+					// 		'selector'    => $icon_selector,
+					// 		'declaration' => 'color: green;'
+					// 	],
+					// ],
 				],
 			]
 		);

--- a/modules/D4Module/D4ModuleTrait/ModuleStylesTrait.php
+++ b/modules/D4Module/D4ModuleTrait/ModuleStylesTrait.php
@@ -113,6 +113,22 @@ trait ModuleStylesTrait {
 							'attrName' => 'content',
 						]
 					),
+
+					// ATTENTION: The code is intentionally added and commented in FE only as an example of expected value format.
+					// If you have custom style processing, the style output should be passed as an `array` of style declarations
+					// to the `styles` property of the `Style::add` method. For example:
+					// [
+					// 	[
+					// 		'atRules'     => false,
+					// 		'selector'    => $order_class . ' .example_d4_module_inner',
+					// 		'declaration' => 'color: red;'
+					// 	],
+					// 	[
+					// 		'atRules'     => '@media only screen and (max-width: 767px)',
+					// 		'selector'    => $order_class . ' .example_d4_module_inner',
+					// 		'declaration' => 'color: green;'
+					// 	],
+					// ],
 				],
 			]
 		);

--- a/modules/DynamicModule/DynamicModuleTrait/ModuleStylesTrait.php
+++ b/modules/DynamicModule/DynamicModuleTrait/ModuleStylesTrait.php
@@ -82,6 +82,22 @@ trait ModuleStylesTrait {
 							'attrName' => 'postTitle',
 						]
 					),
+
+					// ATTENTION: The code is intentionally added and commented in FE only as an example of expected value format.
+					// If you have custom style processing, the style output should be passed as an `array` of style declarations
+					// to the `styles` property of the `Style::add` method. For example:
+					// [
+					// 	[
+					// 		'atRules'     => false,
+					// 		'selector'    => $order_class . ' .example_dynamic_module__inner',
+					// 		'declaration' => 'color: red;'
+					// 	],
+					// 	[
+					// 		'atRules'     => '@media only screen and (max-width: 767px)',
+					// 		'selector'    => $order_class . ' .example_dynamic_module__inner',
+					// 		'declaration' => 'color: green;'
+					// 	],
+					// ],
 				],
 			]
 		);

--- a/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
+++ b/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
@@ -15,13 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 use ET\Builder\FrontEnd\Module\Style;
 use ET\Builder\Packages\Module\Layout\Components\StyleCommon\CommonStyle;
 use ET\Builder\Packages\Module\Options\Css\CssStyle;
-use ET\Builder\Packages\ModuleLibrary\Portfolio\PortfolioModuleTraits\StyleDeclarationTrait;
 use MEE\Modules\ChildModule\ChildModule;
 
 trait ModuleStylesTrait {
 
 	use CustomCssTrait;
-	use StyleDeclarationTrait;
 
 	/**
 	 * Child Module's style components.

--- a/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
+++ b/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
@@ -115,6 +115,22 @@ trait ModuleStylesTrait {
 							'property' => 'font-size',
 						]
 					),
+
+					// ATTENTION: The code is intentionally added and commented in FE only as an example of expected value format.
+					// If you have custom style processing, the style output should be passed as an `array` of style declarations
+					// to the `styles` property of the `Style::add` method. For example:
+					// [
+					// 	[
+					// 		'atRules'     => false,
+					// 		'selector'    => $icon_selector,
+					// 		'declaration' => 'color: red;'
+					// 	],
+					// 	[
+					// 		'atRules'     => '@media only screen and (max-width: 767px)',
+					// 		'selector'    => $icon_selector,
+					// 		'declaration' => 'color: green;'
+					// 	],
+					// ],
 				],
 			]
 		);

--- a/modules/StaticModule/StaticModuleTrait/ModuleStylesTrait.php
+++ b/modules/StaticModule/StaticModuleTrait/ModuleStylesTrait.php
@@ -102,6 +102,22 @@ trait ModuleStylesTrait {
 							'attrName' => 'content',
 						]
 					),
+
+					// ATTENTION: The code is intentionally added and commented in FE only as an example of expected value format.
+					// If you have custom style processing, the style output should be passed as an `array` of style declarations
+					// to the `styles` property of the `Style::add` method. For example:
+					// [
+					// 	[
+					// 		'atRules'     => false,
+					// 		'selector'    => "{$args['orderClass']} .example_static_module__content-container",
+					// 		'declaration' => 'color: red;'
+					// 	],
+					// 	[
+					// 		'atRules'     => '@media only screen and (max-width: 767px)',
+					// 		'selector'    => "{$args['orderClass']} .example_static_module__content-container",
+					// 		'declaration' => 'color: green;'
+					// 	],
+					// ],
 				],
 			]
 		);


### PR DESCRIPTION
# The Issue
## Issue Reference
Fixes: https://github.com/elegantthemes/Divi/issues/40336

## What the feature is
<details>
<summary>🐛 Guideline</summary>

> Explain what the fearure is all about
> Summarize the DoD and how you accomplished it.

</details>

Not an exact feature, but just code example update to follow up recent changes to address [D5 :: Divi 5 Is Generating Much More CSS than Divi 4](https://github.com/elegantthemes/Divi/issues/39663#top).



## Who (else) to contact regarding this feature/area
<details>
<summary>👨‍💻👩‍💻 Guideline</summary>

> List people / team that can be contacted for further information about the change that possibly relates to this feature
> This is usually inferred from commit / PR / discussion.
> IMPORTANT: The goal of this is not to put blame on anyone, but to know who to contact to verify the changes and confirm possible regression. This also aims to guide you to look for and understand beyond the issue and ultimately have some transfer knowledge across the team.

</details>

@ayubadiputra  @Moonomo 



# The Pull Request
## How this pull request accomplishes the feature
<details>
<summary>🤔 Guideline</summary>

> Explain how this PR accomplishes the feature.

</details>

Basically, just need to add a note if 3P devs have custom style processing, the style output should be passed as an `array` of style declarations to the `styles` property of the `Style::add` method. And also, add the example to all example modules `module_styles`. BTW, the code example is intentionally commented to avoid unexpected style output, but still easily to spot.

Thanks to @Moonomo I just need to copy & paste & adapt from [Updated Blog Post for Public Alpha 1:](https://github.com/elegantthemes/submodule-builder-5/pull/4117/files#top).

The reason to add it in `module_styles` of all example modules:
- More relevant due to it's related to `module_styles`.
- It's easy to spot.



## Possible alternate solution
<details>
<summary>🔀 Guideline</summary>

> List other approach (if there’s any) that we could take.
> Explain why those approach isn’t better than the one we are submitting in this PR.
> The goal of this is to be 100% sure that the solution proposed on this PR is the best option that we have right now.

</details>

N/A



## Video proof of Feature working
<details>
<summary>✅ Guideline</summary>

> Explain how do you verify that this PR addressed the issue.
> For example: attaching before and after screenshots / screencast, adding unit test, etc.

</details>

N/A



## Testing this PR
<details>
<summary>🔎 Guideline</summary>

> Provide details, clear steps, and precisely what criteria consititues a QA PASS or FAIL.
> If you are referencing `Replicating Issues` on the above, highlight what is the wrong and correct output.
> For example: “in `master`, you’ll see `x` but in this PR’s branch you’ll see `y`”

</details>

N/A



## Changelog copy
Updated `module_styles` method of all example modules to cover new changes about how to add custom styles output to `Style::add` method. 

## Affected areas
<details>
<summary>🚨 Guideline</summary>

> List the areas of the codebase and/or product that are affected by the changes in this PR. For example:
> * i.e. BB/VB/FE
> * i.e. [Type(s) of modules](https://docs.google.com/spreadsheets/d/1NOg2KNppETydNY_gnd6e3tmXbTxht1L1LB1xEbZFvOg/edit?usp=sharing)
> * i.e. Border Options in the VB

</details>

* Docs


***

<details>
<summary>📝 NOTES</summary>

1. You don’t need to remove the guideline on the blockquoted area. Just keep it as is.
2. The PR template is intentionally made to be verbose. The goal is to guide developer to take a look at the issue from all angles. This is especially needed when we are considering that there are experienced and new developer in the team. On top of guiding this PR also serves as future references.
3. Good PR description is one that provides all information needed regarding the issue and the solution: A description so good whoever review the PR doesn’t need to dig stuff on their own.

</details>
