### PR TITLE
Fixed :: D5 :: Divi Extension Example Modules :: Various PHP warnings and deprecations in plugins

### DIFF
--- a/d5-extension-example-modules.php
+++ b/d5-extension-example-modules.php
@@ -71,7 +71,7 @@ function d5_extension_example_module_enqueue_vb_scripts() {
 		wp_enqueue_style( 'd5-extension-example-modules-builder-vb-bundle-style', "{$plugin_dir_url}styles/vb-bundle.css", array(), '1.0.0' );
 	}
 }
-add_action( 'divi_visual_builder_assets_before_enqueue_packages', 'd5_extension_example_module_enqueue_vb_scripts' );
+add_action( 'et_enqueue_assets', 'd5_extension_example_module_enqueue_vb_scripts' );
 
 /**
  * Enqueue style and scripts of Module Extension Example

--- a/d5-extension-example-modules.php
+++ b/d5-extension-example-modules.php
@@ -71,7 +71,7 @@ function d5_extension_example_module_enqueue_vb_scripts() {
 		wp_enqueue_style( 'd5-extension-example-modules-builder-vb-bundle-style', "{$plugin_dir_url}styles/vb-bundle.css", array(), '1.0.0' );
 	}
 }
-add_action( 'et_enqueue_assets', 'd5_extension_example_module_enqueue_vb_scripts' );
+add_action( 'divi_visual_builder_assets_before_enqueue_scripts', 'd5_extension_example_module_enqueue_vb_scripts' );
 
 /**
  * Enqueue style and scripts of Module Extension Example

--- a/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
+++ b/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
@@ -15,9 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 use ET\Builder\FrontEnd\Module\Style;
 use ET\Builder\Packages\Module\Layout\Components\StyleCommon\CommonStyle;
 use ET\Builder\Packages\Module\Options\Css\CssStyle;
-use ET\Builder\Packages\ModuleLibrary\Portfolio\PortfolioModuleTraits\StyleDeclarationTrait;
 use MEE\Modules\ChildModule\ChildModule;
-
+use MEE\Modules\ChildModule\ChildModuleTrait\StyleDeclarationTrait;
 trait ModuleStylesTrait {
 
 	use CustomCssTrait;

--- a/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
+++ b/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
@@ -15,8 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 use ET\Builder\FrontEnd\Module\Style;
 use ET\Builder\Packages\Module\Layout\Components\StyleCommon\CommonStyle;
 use ET\Builder\Packages\Module\Options\Css\CssStyle;
+use ET\Builder\Packages\ModuleLibrary\Portfolio\PortfolioModuleTraits\StyleDeclarationTrait;
 use MEE\Modules\ChildModule\ChildModule;
-use MEE\Modules\ChildModule\ChildModuleTrait\StyleDeclarationTrait;
+
 trait ModuleStylesTrait {
 
 	use CustomCssTrait;


### PR DESCRIPTION
# The Issue
## Issue Reference
Fixes: https://github.com/elegantthemes/Divi/issues/40397

## What the issue is
<details>
<summary>🐛 Guideline</summary>

> Explain what the issue is all about.
> Sometimes what is being reported and the problem can be different.
> If this is the case, highlight the difference.

</details>

Fix various PHP warnings and deprecations:
- [x] [22-Oct-2024 14:06:52 UTC] PHP Deprecated:  Hook divi_visual_builder_assets_before_enqueue_packages is <strong>deprecated</strong> since version 5.0.0-public-alpha.0! Use divi_visual_builder_assets_before_enqueue_scripts instead. in /Users/ayubadiputra/Local Sites/etdev-d5-3ps/app/public/wp-includes/functions.php on line 6085



## Replicating issue
<details>
<summary>📝 Guideline</summary>

> List the steps that need to be taken to replicate the issue.
> Provide annotated screenshot, screencast video and/or exported layout
> Export the layout from D4 so it can be checked on both

</details>


## How to Reproduce/Test
- Install and activate this plugin: [d5-extension-example-modules(with-bug).zip](https://github.com/user-attachments/files/17588712/d5-extension-example-modules.with-bug.zip).
- Check VB - There is deprecation warnings



## Where does the issue come from

<details>
<summary>🗺 Guideline</summary>

> Give references that you use to reach the conclusion above.
> It can be link to file / commit / PR / discussion, annotated screenshot, screencast, or anything.
> If you are rebuilding D4 features or fixing issues where the expected behavior should be identical with how it works on D4, provide references on how things are working in D4.

</details>

After this commit merged: https://github.com/elegantthemes/submodule-builder-5/commit/34f122332eb758ce1f1621ec41f3bab6fe026880.



## When the issue start to happen
<details>
<summary>⌛️ Guideline</summary>

> Conclude when did the issue start to appear.
> Use relative time or relative to certain feature like “during dev beta.x” or “during d5 design implementation”).
> Use git blame.

</details>

After public alpha release.

## Who to contact regarding the issue
<details>
<summary>👨‍💻👩‍💻 Guideline</summary>

> List people / team that can be contacted for further information about the change that possibly cause the issue.
> This is usually inferred from commit / PR / discussion.
> IMPORTANT: The goal of this is not to put blame on anyone, but to know who to contact to verify the changes and confirm possible regression. This also aims to guide you to look for and understand beyond the issue and ultimately have some transfer knowledge across the team.

</details>

@robicse11127 



## Why the issue happened

<details>
<summary>❓ Guideline</summary>

> You have explained the what, where, when and who.
> Now explain to me why it happened.
> For example: it hasn’t build yet, at the time we have different assumption, it seems like a typo, etc.

</details>

There were basically 2 issues 
- The `StyleDeclarationTrait` was not loaded correctly
- This `divi_visual_builder_assets_before_enqueue_packages` particular hook was deprecated and we needed to use the `et_enqueue_assets`


# The Pull Request
## How this pull request fixes the issue
<details>
<summary>🤔 Guideline</summary>

> Explain how this PR fixes the issue.

</details>

To fix this issue we can simply just remove it because this trait is never being used in Parent Module style. So, we can simply remove the code to fix the fatal error.
And for the deprecation issue we needed update the action hook.


## Possible alternate solution
<details>
<summary>🔀 Guideline</summary>

> List other approach (if there’s any) that we could take.
> Explain why those approach isn’t better than the one we are submitting in this PR.
> The goal of this is to be 100% sure that the solution proposed on this PR is the best option that we have right now.

</details>

N/A



## How the PR was verified
<details>
<summary>✅ Guideline</summary>

> Explain how do you verify that this PR addressed the issue.
> For example: attaching before and after screenshots / screencast, adding unit test, etc.

</details>

There should be no warning errors after reload on VB or in debug.log file.
![image](https://github.com/user-attachments/assets/fc96e3b0-2acd-4a7a-ac99-aa3c683d19af)



## Testing this PR
<details>
<summary>🔎 Guideline</summary>

> Provide details, clear steps, and precisely what criteria consititues a QA PASS or FAIL.
> If you are referencing `Replicating Issues` on the above, highlight what is the wrong and correct output.
> For example: “in `master`, you’ll see `x` but in this PR’s branch you’ll see `y`”

</details>

- Make sure you have WP and ET debug active, so you can see the warnings in `debug.log` file.
- Install and activate this plugin [d5-extension-example-modules(fixed).zip](https://github.com/user-attachments/files/17588717/d5-extension-example-modules.fixed.zip).
- Open a post/page with VB.
- Check the `debug.log` file and you should no longer the issue related to deprecated `divi_visual_builder_assets_before_enqueue_packages` hook.
- Also check on VB, there should be no warning related to this deprecated `divi_visual_builder_assets_before_enqueue_packages` hook.



## Changelog copy
Fixed the PHP warnings generated in debug.log file.

## Affected areas
<details>
<summary>🚨 Guideline</summary>

> List the areas of the codebase and/or product that are affected by the changes in this PR. For example:
> * i.e. BB/VB/FE
> * i.e. [Type(s) of modules](https://docs.google.com/spreadsheets/d/1NOg2KNppETydNY_gnd6e3tmXbTxht1L1LB1xEbZFvOg/edit?usp=sharing)
> * i.e. Border Options in the VB

</details>

- VB
- Check debug.log


***

<details>
<summary>📝 NOTES</summary>

1. You don’t need to remove the guideline on the blockquoted area. Just keep it as is.
2. The PR template is intentionally made to be verbose. The goal is to guide developer to take a look at the issue from all angles. This is especially needed when we are considering that there are experienced and new developer in the team. On top of guiding this PR also serves as future references.
3. Good PR description is one that provides all information needed regarding the issue and the solution: A description so good whoever review the PR doesn’t need to dig stuff on their own.

</details>
