### PR TITLE
Refactor gulpfile.js to use dynamic import for gulp-zip

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
-const { src, dest } = require( 'gulp' );
-const gulpZip = require( 'gulp-zip' );
+const { src, dest } = require('gulp');
 const package = require('./package.json');
 
 const files = [
@@ -28,6 +27,11 @@ const files = [
     '!composer.lock',
 ];
 
-const zip = () => src( files ).pipe( gulpZip( package.name + '-v' + package.version + '.zip' ) ).pipe( dest( './' ) );
+const zip = async () => {
+    const gulpZip = (await import('gulp-zip')).default;
+    return src(files)
+        .pipe(gulpZip(package.name + '-v' + package.version + '.zip'))
+        .pipe(dest('./'));
+};
 
 exports.zip = zip;


### PR DESCRIPTION
Issue: https://github.com/elegantthemes/Divi/issues/40436
- Replaced require('gulp-zip') with dynamic import('gulp-zip') to support ES Module.
- Marked the zip function as async to use await for the dynamic import.
- Ensured compatibility with the current version of gulp-zip, resolving ERR_REQUIRE_ESM error.

https://github.com/user-attachments/assets/d8373b4e-e5fc-4574-8bf9-5377e719bd40

Changelog Copy:  Fixed an issue with generating the zip file by updating compatibility with the latest tool version.
