### PR TITLE
40615 :: D5 :: 3PS :: Transitions :: How To Register Settings/Elements With Transitions Feature

### DIFF
--- a/modules/ChildModule/ChildModuleTrait/ModuleStylesTrait.php
+++ b/modules/ChildModule/ChildModuleTrait/ModuleStylesTrait.php
@@ -57,7 +57,6 @@ trait ModuleStylesTrait {
 		$parent_default_attributes = ModuleRegistration::get_default_attrs( 'example/parent-module' );
 		$parent_attrs_with_default = array_replace_recursive( $parent_default_attributes, $parent_attrs );
 
-		$icon_selector              = "{$order_class} .example_child_module__icon.et-pb-icon";
 		$content_container_selector = "{$order_class} .example_child_module__content-container";
 
 		Style::add(
@@ -72,23 +71,19 @@ trait ModuleStylesTrait {
 						[
 							'attrName'   => 'module',
 							'styleProps' => [
-								'disabledOn' => [
+								'disabledOn'     => [
 									'disabledModuleVisibility' => $settings['disabledModuleVisibility'] ?? null,
 								],
+								'advancedStyles' => [
+									[
+										'componentName' => 'divi/text',
+										'props'         => [
+											'selector' => $content_container_selector,
+											'attr'     => $attrs['module']['advanced']['text'] ?? [],
+										]
+									]
+								]
 							],
-						]
-					),
-					TextStyle::style(
-						[
-							'selector' => $content_container_selector,
-							'attr'     => $attrs['module']['advanced']['text'] ?? [],
-						]
-					),
-					CssStyle::style(
-						[
-							'selector'  => $args['orderClass'],
-							'attr'      => $attrs['css'] ?? [],
-							'cssFields' => self::custom_css(),
 						]
 					),
 
@@ -107,25 +102,47 @@ trait ModuleStylesTrait {
 					),
 
 					// Icon.
-					CommonStyle::style(
+					$elements->style(
 						[
-							'selector'            => $icon_selector,
-							'attr'                => $attrs['icon']['innerContent'] ?? $parent_attrs_with_default['icon']['innerContent'] ?? [],
-							'declarationFunction' => [ ChildModule::class, 'icon_font_declaration' ],
+							'attrName'   => 'icon',
+							'styleProps' => [
+								'advancedStyles' => [
+									[
+										'componentName' => 'divi/common',
+										'props'         => [
+											'attr'                => $attrs['icon']['innerContent'] ?? $parent_attrs_with_default['icon']['innerContent'] ?? [],
+											'declarationFunction' => [ChildModule::class, 'icon_font_declaration'],
+										]
+									],
+									[
+										'componentName' => 'divi/common',
+										'props'         => [
+											'attr'     => $attrs['icon']['advanced']['color'] ?? $parent_attrs_with_default['icon']['advanced']['color'] ?? [],
+											'property' => 'color',
+										]
+									],
+									[
+										'componentName' => 'divi/common',
+										'props'         => [
+											'attr'     => $attrs['icon']['advanced']['size'] ?? $parent_attrs_with_default['icon']['advanced']['size'] ?? [],
+											'property' => 'font-size',
+										]
+									],
+								]
+							]
 						]
 					),
-					CommonStyle::style(
+
+					/**
+					 * We need to add CssStyle at the very bottom of other
+					 * components so that custom css can override module styles
+					 * till we find a more elegant solution.
+					 */
+					CssStyle::style(
 						[
-							'selector' => $icon_selector,
-							'attr'     => $attrs['icon']['advanced']['color'] ?? $parent_attrs_with_default['icon']['advanced']['color'] ?? [],
-							'property' => 'color',
-						]
-					),
-					CommonStyle::style(
-						[
-							'selector' => $icon_selector,
-							'attr'     => $attrs['icon']['advanced']['size'] ?? $parent_attrs_with_default['icon']['advanced']['size'] ?? [],
-							'property' => 'font-size',
+							'selector'  => $args['orderClass'],
+							'attr'      => $attrs['css'] ?? [],
+							'cssFields' => self::custom_css(),
 						]
 					),
 

--- a/modules/ChildModule/ChildModuleTrait/ModuleStylesTrait.php
+++ b/modules/ChildModule/ChildModuleTrait/ModuleStylesTrait.php
@@ -133,7 +133,7 @@ trait ModuleStylesTrait {
 						]
 					),
 
-					/**
+					/*
 					 * We need to add CssStyle at the very bottom of other
 					 * components so that custom css can override module styles
 					 * till we find a more elegant solution.

--- a/modules/ChildModule/ChildModuleTrait/StyleDeclarationTrait.php
+++ b/modules/ChildModule/ChildModuleTrait/StyleDeclarationTrait.php
@@ -51,7 +51,7 @@ trait StyleDeclarationTrait {
 			$style_declarations->add( 'font-family', $font_family );
 		}
 
-		return $style_declarations->value;
+		return $style_declarations->value();
 	}
 
 }

--- a/modules/DynamicModule/DynamicModuleTrait/ModuleStylesTrait.php
+++ b/modules/DynamicModule/DynamicModuleTrait/ModuleStylesTrait.php
@@ -63,13 +63,16 @@ trait ModuleStylesTrait {
 								'disabledOn'               => [
 									'disabledModuleVisibility' => $settings['disabledModuleVisibility'] ?? null,
 								],
+								'advancedStyles'           => [
+									[
+										'componentName' => 'divi/text',
+										'props'         => [
+											'selector' => $order_class . ' .example_dynamic_module__inner',
+											'attr'     => $attrs['module']['advanced']['text'] ?? [],
+										],
+									],
+								],
 							],
-						]
-					),
-					TextStyle::style(
-						[
-							'selector' => $order_class . ' .example_dynamic_module__inner',
-							'attr'     => $attrs['module']['advanced']['text'] ?? [],
 						]
 					),
 					$elements->style(

--- a/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
+++ b/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
@@ -51,8 +51,6 @@ trait ModuleStylesTrait {
 		$elements     = $args['elements'];
 		$settings     = $args['settings'] ?? [];
 
-		$icon_selector = "{$order_class} .et-pb-icon";
-
 		Style::add(
 			[
 				'id'            => $args['id'],
@@ -71,13 +69,6 @@ trait ModuleStylesTrait {
 							],
 						]
 					),
-					CssStyle::style(
-						[
-							'selector'  => $args['orderClass'],
-							'attr'      => $attrs['css'] ?? [],
-							'cssFields' => self::custom_css(),
-						]
-					),
 
 					// Title.
 					$elements->style(
@@ -94,25 +85,47 @@ trait ModuleStylesTrait {
 					),
 
 					// Icon.
-					CommonStyle::style(
+					$elements->style(
 						[
-							'selector'            => $icon_selector,
-							'attr'                => $attrs['icon']['innerContent'] ?? [],
-							'declarationFunction' => [ ChildModule::class, 'icon_font_declaration' ],
+							'attrName'   => 'icon',
+							'styleProps' => [
+								'advancedStyles' => [
+									[
+										'componentName' => 'divi/common',
+										'props'         => [
+											'attr'                => $attrs['icon']['innerContent'] ?? [],
+											'declarationFunction' => [ChildModule::class, 'icon_font_declaration'],
+										]
+									],
+									[
+										'componentName' => 'divi/common',
+										'props'         => [
+											'attr'     => $attrs['icon']['advanced']['color'] ?? [],
+											'property' => 'color',
+										]
+									],
+									[
+										'componentName' => 'divi/common',
+										'props'         => [
+											'attr'     => $attrs['icon']['advanced']['size'] ?? [],
+											'property' => 'font-size',
+										]
+									],
+								]
+							]
 						]
 					),
-					CommonStyle::style(
+
+					/**
+					 * We need to add CssStyle at the very bottom of other
+					 * components so that custom css can override module styles
+					 * till we find a more elegant solution.
+					 */
+					CssStyle::style(
 						[
-							'selector' => $icon_selector,
-							'attr'     => $attrs['icon']['advanced']['color'] ?? [],
-							'property' => 'color',
-						]
-					),
-					CommonStyle::style(
-						[
-							'selector' => $icon_selector,
-							'attr'     => $attrs['icon']['advanced']['size'] ?? [],
-							'property' => 'font-size',
+							'selector'  => $args['orderClass'],
+							'attr'      => $attrs['css'] ?? [],
+							'cssFields' => self::custom_css(),
 						]
 					),
 

--- a/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
+++ b/modules/ParentModule/ParentModuleTrait/ModuleStylesTrait.php
@@ -116,7 +116,7 @@ trait ModuleStylesTrait {
 						]
 					),
 
-					/**
+					/*
 					 * We need to add CssStyle at the very bottom of other
 					 * components so that custom css can override module styles
 					 * till we find a more elegant solution.

--- a/modules/StaticModule/StaticModuleTrait/ModuleStylesTrait.php
+++ b/modules/StaticModule/StaticModuleTrait/ModuleStylesTrait.php
@@ -62,23 +62,19 @@ trait ModuleStylesTrait {
 						[
 							'attrName'   => 'module',
 							'styleProps' => [
-								'disabledOn' => [
+								'disabledOn'     => [
 									'disabledModuleVisibility' => $settings['disabledModuleVisibility'] ?? null,
 								],
+								'advancedStyles' => [
+									[
+										'componentName' => 'divi/text',
+										'props'         => [
+											'selector' => "{$args['orderClass']} .example_static_module__content-container",
+											'attr'     => $attrs['module']['advanced']['text'] ?? [],
+										]
+									]
+								]
 							],
-						]
-					),
-					TextStyle::style(
-						[
-							'selector' => "{$args['orderClass']} .example_static_module__content-container",
-							'attr'     => $attrs['module']['advanced']['text'] ?? [],
-						]
-					),
-					CssStyle::style(
-						[
-							'selector'  => $args['orderClass'],
-							'attr'      => $attrs['css'] ?? [],
-							'cssFields' => StaticModule::custom_css(),
 						]
 					),
 
@@ -100,6 +96,19 @@ trait ModuleStylesTrait {
 					$elements->style(
 						[
 							'attrName' => 'content',
+						]
+					),
+
+					/**
+					 * We need to add CssStyle at the very bottom of other
+					 * components so that custom css can override module styles
+					 * till we find a more elegant solution.
+					 */
+					CssStyle::style(
+						[
+							'selector'  => $args['orderClass'],
+							'attr'      => $attrs['css'] ?? [],
+							'cssFields' => StaticModule::custom_css(),
 						]
 					),
 

--- a/modules/StaticModule/StaticModuleTrait/ModuleStylesTrait.php
+++ b/modules/StaticModule/StaticModuleTrait/ModuleStylesTrait.php
@@ -99,7 +99,7 @@ trait ModuleStylesTrait {
 						]
 					),
 
-					/**
+					/*
 					 * We need to add CssStyle at the very bottom of other
 					 * components so that custom css can override module styles
 					 * till we find a more elegant solution.

--- a/src/components/child-module/styles.tsx
+++ b/src/components/child-module/styles.tsx
@@ -94,7 +94,7 @@ import { ParentModuleAttrs } from "../parent-module/types";
         }
       })}
 
-      {/**
+      {/*
        * We need to add CssStyle at the very bottom of other components
        * so that custom css can override module styles till we find a
        * more elegant solution.

--- a/src/components/child-module/styles.tsx
+++ b/src/components/child-module/styles.tsx
@@ -95,9 +95,9 @@ import { ParentModuleAttrs } from "../parent-module/types";
       })}
 
       {/**
-       * We need to add CssStyle at the very bottom of other
-			 * components so that custom css can override module styles
-			 * till we find a more elegant solution.
+       * We need to add CssStyle at the very bottom of other components
+       * so that custom css can override module styles till we find a
+       * more elegant solution.
        */}
       <CssStyle
         selector={orderClass}

--- a/src/components/child-module/styles.tsx
+++ b/src/components/child-module/styles.tsx
@@ -31,7 +31,6 @@ import { ParentModuleAttrs } from "../parent-module/types";
   state,
   noStyleTag,
 }: StylesProps<ChildModuleAttrs, ParentModuleAttrs>): ReactElement => {
-  const iconSelector = `${orderClass} .example_child_module__icon.et-pb-icon`;
   const contentContainerSelector = `${orderClass} .example_child_module__content-container`;
 
   return (
@@ -43,17 +42,17 @@ import { ParentModuleAttrs } from "../parent-module/types";
           disabledOn: {
             disabledModuleVisibility: settings?.disabledModuleVisibility,
           },
+          advancedStyles: [
+            {
+              componentName: 'divi/text',
+              props: {
+                selector: contentContainerSelector,
+                attr: attrs?.module?.advanced?.text,
+              }
+            }
+          ]
         },
       })}
-      <TextStyle
-        selector={contentContainerSelector}
-        attr={attrs?.module?.advanced?.text}
-      />
-      <CssStyle
-        selector={orderClass}
-        attr={attrs.css}
-        cssFields={cssFields}
-      />
 
       {/* Title */}
       {elements.style({
@@ -66,20 +65,44 @@ import { ParentModuleAttrs } from "../parent-module/types";
       })}
 
       {/* Icon */}
-      <CommonStyle
-        selector={iconSelector}
-        attr={attrs?.icon?.innerContent ?? parentAttrs?.icon?.innerContent}
-        declarationFunction={iconFontDeclaration}
-      />
-      <CommonStyle
-        selector={iconSelector}
-        attr={attrs?.icon?.advanced?.color ?? parentAttrs?.icon?.advanced?.color}
-        property="color"
-      />
-      <CommonStyle
-        selector={iconSelector}
-        attr={attrs?.icon?.advanced?.size ?? parentAttrs?.icon?.advanced?.size}
-        property="font-size"
+      {elements.style({
+        attrName: 'icon',
+        styleProps: {
+          advancedStyles: [
+            {
+              componentName: "divi/common",
+              props: {
+                attr: attrs?.icon?.innerContent ?? parentAttrs?.icon?.innerContent,
+                declarationFunction: iconFontDeclaration,
+              }
+            },
+            {
+              componentName: "divi/common",
+              props: {
+                attr: attrs?.icon?.advanced?.color ?? parentAttrs?.icon?.advanced?.color,
+                property:"color"
+              }
+            },
+            {
+              componentName: "divi/common",
+              props: {
+                attr:attrs?.icon?.advanced?.size ?? parentAttrs?.icon?.advanced?.size,
+                property:"font-size"
+              }
+            }
+          ]
+        }
+      })}
+
+      {/**
+       * We need to add CssStyle at the very bottom of other
+			 * components so that custom css can override module styles
+			 * till we find a more elegant solution.
+       */}
+      <CssStyle
+        selector={orderClass}
+        attr={attrs.css}
+        cssFields={cssFields}
       />
     </StyleContainer>
   );

--- a/src/components/dynamic-module/styles.tsx
+++ b/src/components/dynamic-module/styles.tsx
@@ -33,12 +33,17 @@ import { DynamicModuleAttrs } from './types';
           disabledOn: {
             disabledModuleVisibility: settings?.disabledModuleVisibility,
           },
+          advancedStyles: [
+            {
+              componentName: "divi/text",
+              props: {
+                selector:`${orderClass} .example_dynamic_module__inner`,
+                attr:attrs?.module?.advanced?.text,
+              }
+            }
+          ]
         },
       })}
-      <TextStyle
-        selector={`${orderClass} .example_dynamic_module__inner`}
-        attr={attrs?.module?.advanced?.text}
-      />
       {elements.style({
         attrName: 'title',
       })}

--- a/src/components/parent-module/styles.tsx
+++ b/src/components/parent-module/styles.tsx
@@ -28,8 +28,6 @@ import { iconFontDeclaration } from '../child-module/style-declarations';
   state,
   noStyleTag,
 }: StylesProps<ParentModuleAttrs>): ReactElement => {
-  const iconSelector = `${orderClass} .et-pb-icon`;
-
   return (
     <StyleContainer mode={mode} state={state} noStyleTag={noStyleTag}>
       {/* Module */}
@@ -41,11 +39,6 @@ import { iconFontDeclaration } from '../child-module/style-declarations';
           },
         },
       })}
-      <CssStyle
-        selector={orderClass}
-        attr={attrs.css}
-        cssFields={cssFields}
-      />
 
       {/* Title */}
       {elements.style({
@@ -58,20 +51,44 @@ import { iconFontDeclaration } from '../child-module/style-declarations';
       })}
 
       {/* Icon */}
-      <CommonStyle
-        selector={iconSelector}
-        attr={attrs?.icon?.innerContent ?? {}}
-        declarationFunction={iconFontDeclaration}
-      />
-      <CommonStyle
-        selector={iconSelector}
-        attr={attrs?.icon?.advanced?.color}
-        property="color"
-      />
-      <CommonStyle
-        selector={iconSelector}
-        attr={attrs?.icon?.advanced?.size}
-        property="font-size"
+      {elements.style({
+        attrName: 'icon',
+        styleProps: {
+          advancedStyles: [
+            {
+              componentName: "divi/common",
+              props: {
+                attr:attrs?.icon?.innerContent ?? {},
+                declarationFunction:iconFontDeclaration,
+              }
+            },
+            {
+              componentName: "divi/common",
+              props: {
+                attr: attrs?.icon?.advanced?.color,
+                property:"color"
+              }
+            },
+            {
+              componentName: "divi/common",
+              props: {
+                attr:attrs?.icon?.advanced?.size,
+                property:"font-size"
+              }
+            }
+          ]
+        }
+      })}
+
+      {/**
+       * We need to add CssStyle at the very bottom of other
+			 * components so that custom css can override module styles
+			 * till we find a more elegant solution.
+       */}
+      <CssStyle
+        selector={orderClass}
+        attr={attrs.css}
+        cssFields={cssFields}
       />
     </StyleContainer>
   )

--- a/src/components/parent-module/styles.tsx
+++ b/src/components/parent-module/styles.tsx
@@ -80,7 +80,7 @@ import { iconFontDeclaration } from '../child-module/style-declarations';
         }
       })}
 
-      {/**
+      {/*
        * We need to add CssStyle at the very bottom of other components
        * so that custom css can override module styles till we find a
        * more elegant solution.

--- a/src/components/parent-module/styles.tsx
+++ b/src/components/parent-module/styles.tsx
@@ -81,9 +81,9 @@ import { iconFontDeclaration } from '../child-module/style-declarations';
       })}
 
       {/**
-       * We need to add CssStyle at the very bottom of other
-			 * components so that custom css can override module styles
-			 * till we find a more elegant solution.
+       * We need to add CssStyle at the very bottom of other components
+       * so that custom css can override module styles till we find a
+       * more elegant solution.
        */}
       <CssStyle
         selector={orderClass}

--- a/src/components/static-module/styles.tsx
+++ b/src/components/static-module/styles.tsx
@@ -38,18 +38,17 @@ export const ModuleStyles = ({
           disabledOn: {
             disabledModuleVisibility: settings?.disabledModuleVisibility,
           },
+          advancedStyles: [
+            {
+              componentName: "divi/text",
+              props: {
+                selector:textSelector ,
+                attr: attrs?.module?.advanced?.text,
+              }
+            }
+          ]
         },
       })}
-      <TextStyle
-        selector={textSelector}
-        attr={attrs?.module?.advanced?.text}
-      />
-      <CssStyle
-        selector={orderClass}
-        attr={attrs.css}
-        cssFields={cssFields}
-      />
-
       {/* Image */}
       {elements.style({
         attrName: 'image',
@@ -64,6 +63,17 @@ export const ModuleStyles = ({
       {elements.style({
         attrName: 'content',
       })}
+
+      {/**
+       * We need to add CssStyle at the very bottom of other
+			 * components so that custom css can override module styles
+			 * till we find a more elegant solution.
+       */}
+      <CssStyle
+        selector={orderClass}
+        attr={attrs.css}
+        cssFields={cssFields}
+      />
 
     </StyleContainer>
   );

--- a/src/components/static-module/styles.tsx
+++ b/src/components/static-module/styles.tsx
@@ -64,7 +64,7 @@ export const ModuleStyles = ({
         attrName: 'content',
       })}
 
-      {/**
+      {/*
        * We need to add CssStyle at the very bottom of other components
        * so that custom css can override module styles till we find a
        * more elegant solution.

--- a/src/components/static-module/styles.tsx
+++ b/src/components/static-module/styles.tsx
@@ -65,9 +65,9 @@ export const ModuleStyles = ({
       })}
 
       {/**
-       * We need to add CssStyle at the very bottom of other
-			 * components so that custom css can override module styles
-			 * till we find a more elegant solution.
+       * We need to add CssStyle at the very bottom of other components
+       * so that custom css can override module styles till we find a
+       * more elegant solution.
        */}
       <CssStyle
         selector={orderClass}


### PR DESCRIPTION
# The Issue
## Issue Reference
Fixes: https://github.com/elegantthemes/Divi/issues/40615

## What the feature is
<details>
<summary>🐛 Guideline</summary>

> Explain what the fearure is all about
> Summarize the DoD and how you accomplished it.

</details>

The issue began when a user on Discord reported that transitions weren't working for the `CommonStyle` component on the front end. The user had tried applying both `advancedStyles` and the `CommonStyle` component directly, but neither approach resolved the problem.

To provide a working example, we reviewed our Extensions Example Plugin, only to discover that it wasn’t set up to use `advancedStyles` for components that it supports, such as `CommonStyle` and `TextStyle`. Based on this, we decided to update the Extensions Example Plugin to incorporate `advancedStyles` within the `Elements` class, ensuring compatibility wherever necessary on both the Visual Builder (VB) and frontend (FE).



## Who (else) to contact regarding this feature/area
<details>
<summary>👨‍💻👩‍💻 Guideline</summary>

> List people / team that can be contacted for further information about the change that possibly relates to this feature
> This is usually inferred from commit / PR / discussion.
> IMPORTANT: The goal of this is not to put blame on anyone, but to know who to contact to verify the changes and confirm possible regression. This also aims to guide you to look for and understand beyond the issue and ultimately have some transfer knowledge across the team.

</details>

@rupakdhiman 


# The Pull Request
## How this pull request accomplishes the feature
<details>
<summary>🤔 Guideline</summary>

> Explain how this PR accomplishes the feature.

</details>

This PR introduces the use of `advancedStyles` in the elements class on both the Visual Builder (VB) and frontend (FE). Previously, we relied on components like `CommonStyle` to achieve the desired styling results. However, `advancedStyles` should be used to apply additional attribute-specific styles, integrating them within the elements class to work in tandem with the `CssStyle` component. This approach addresses an issue where custom CSS in the Advanced tab of the module settings wasn’t properly overriding default styles.

Additionally, we've positioned the `CssStyle` component at the very bottom of the component hierarchy. This placement is essential for resolving the CSS override issue, as documented [here](https://github.com/elegantthemes/Divi/issues/38331).

## Note (QA)
There are some PHP warnings on the frontend, which can also be seen in the video attached. After discussion we will create a new issue to address those warnings.

```
Notice: Undefined property: ET\Builder\Packages\StyleLibrary\Utils\StyleDeclarations::$value in /Users/rupakdhiman/Work/ElegantThemes/divi/app/public/wp-content/plugins/d5-extension-example-modules/modules/ChildModule/ChildModuleTrait/StyleDeclarationTrait.php on line 54
```


## Possible alternate solution
<details>
<summary>🔀 Guideline</summary>

> List other approach (if there’s any) that we could take.
> Explain why those approach isn’t better than the one we are submitting in this PR.
> The goal of this is to be 100% sure that the solution proposed on this PR is the best option that we have right now.

</details>

Using Style components directly, without utilizing `advancedStyles`, but this is generally discouraged unless there is a specific scenario that requires it. The preferred approach is to use `advancedStyles` to ensure better flexibility and compatibility across components.



## Video proof of Feature working
<details>
<summary>✅ Guideline</summary>

> Explain how do you verify that this PR addressed the issue.
> For example: attaching before and after screenshots / screencast, adding unit test, etc.

</details>


https://github.com/user-attachments/assets/4d81be79-c1de-4bee-b374-453a648825f8




## Testing this PR
<details>
<summary>🔎 Guideline</summary>

> Provide details, clear steps, and precisely what criteria consititues a QA PASS or FAIL.
> If you are referencing `Replicating Issues` on the above, highlight what is the wrong and correct output.
> For example: “in `master`, you’ll see `x` but in this PR’s branch you’ll see `y`”

</details>

- Download the plugin zip file [d5-extension-example-modules.zip](https://github.com/user-attachments/files/17745705/d5-extension-example-modules.zip)
- (Optional) if you are running this on local please run `npm install` to generate `node_modules` due to excessive size I have deleted the folder.
- Open Visual Builder
- Add Parent module
- Add icon and add some icon styles for hover as well
- Make sure transitions are working on VB and FE




## Changelog copy
- Update: Use `advancedStyles` for module additional styles output

## Affected areas
<details>
<summary>🚨 Guideline</summary>

> List the areas of the codebase and/or product that are affected by the changes in this PR. For example:
> * i.e. BB/VB/FE
> * i.e. [Type(s) of modules](https://docs.google.com/spreadsheets/d/1NOg2KNppETydNY_gnd6e3tmXbTxht1L1LB1xEbZFvOg/edit?usp=sharing)
> * i.e. Border Options in the VB

</details>

- VB
- FE


***

<details>
<summary>📝 NOTES</summary>

1. You don’t need to remove the guideline on the blockquoted area. Just keep it as is.
2. The PR template is intentionally made to be verbose. The goal is to guide developer to take a look at the issue from all angles. This is especially needed when we are considering that there are experienced and new developer in the team. On top of guiding this PR also serves as future references.
3. Good PR description is one that provides all information needed regarding the issue and the solution: A description so good whoever review the PR doesn’t need to dig stuff on their own.

</details>
