### PR TITLE
fix(D5, 3PS): Fixed extension example to use new PackageBuildManager for enqueueing assets

### DIFF
--- a/d5-extension-example-modules.php
+++ b/d5-extension-example-modules.php
@@ -58,16 +58,22 @@ function d5_extension_example_module_enqueue_vb_scripts() {
 	if ( et_builder_d5_enabled() && et_core_is_fb_enabled() ) {
 		$plugin_dir_url = plugin_dir_url( __FILE__ );
 
-		wp_enqueue_script(
-			'd5-extension-example-modules-builder-bundle-script',
-			"{$plugin_dir_url}scripts/bundle.js",
-			array(
-				'divi-module-library',
-				'divi-vendor-wp-hooks',
-			),
-			'1.0.0',
-			true
+		\ET\Builder\VisualBuilder\Assets\PackageBuildManager::register_package_build(
+			[
+				'name'   => 'd5-extension-example-modules-builder-bundle-script',
+				'version' => '1.0.0',
+				'script' => [
+					'src' => "{$plugin_dir_url}scripts/bundle.js",
+					'deps'               => [
+						'divi-module-library',
+						'divi-vendor-wp-hooks',
+					],
+					'enqueue_top_window' => false,
+					'enqueue_app_window' => true,
+				],
+			]
 		);
+
 		wp_enqueue_style( 'd5-extension-example-modules-builder-vb-bundle-style', "{$plugin_dir_url}styles/vb-bundle.css", array(), '1.0.0' );
 	}
 }

--- a/d5-extension-example-modules.php
+++ b/d5-extension-example-modules.php
@@ -74,7 +74,18 @@ function d5_extension_example_module_enqueue_vb_scripts() {
 			]
 		);
 
-		wp_enqueue_style( 'd5-extension-example-modules-builder-vb-bundle-style', "{$plugin_dir_url}styles/vb-bundle.css", array(), '1.0.0' );
+		\ET\Builder\VisualBuilder\Assets\PackageBuildManager::register_package_build(
+			[
+				'name'   => 'd5-extension-example-modules-builder-vb-bundle-style',
+				'version' => '1.0.0',
+				'style' => [
+					'src' => "{$plugin_dir_url}styles/vb-bundle.css",
+					'deps'               => [],
+					'enqueue_top_window' => false,
+					'enqueue_app_window' => true,
+				],
+			]
+		);
 	}
 }
 add_action( 'divi_visual_builder_assets_before_enqueue_scripts', 'd5_extension_example_module_enqueue_vb_scripts' );

--- a/divi-4/modules/Divi4OnlyModule/Divi4OnlyModule.php
+++ b/divi-4/modules/Divi4OnlyModule/Divi4OnlyModule.php
@@ -135,7 +135,7 @@ class D4_Only_Module extends ET_Builder_Module {
 	 *
 	 * @return string module's rendered output
 	 */
-	function render( $attrs, $content = null, $render_slug ) {
+	function render( $attrs, $content, $render_slug ) {
 		// Module specific props added on $this->get_fields()
 		$title        = $this->props['title'];
 		$header_level = et_pb_process_header_level( $this->props['header_level'], 'h2' );


### PR DESCRIPTION
Fixes: https://github.com/elegantthemes/Divi/issues/40440

Updated the plugin to use the new Divi API to register Visual Builder's styles and scripts.