### PR TITLE
D5 :: 3PS :: Webpack :: Conversion Outline Plugin :: Avoid watch loop when `conversion-outline.json` file is unchanged

### DIFF
--- a/webpack/config/plugins/conversion-outline-json-plugin.js
+++ b/webpack/config/plugins/conversion-outline-json-plugin.js
@@ -76,8 +76,20 @@ class ConversionOutlineJsonPlugin {
                   "conversion-outline.json"
                 );
 
-                // Write the JSON content to a `conversion-outline.json` file in the same directory
-                await fsp.writeFile(outputPath, jsonContent);
+                // Avoid rewriting when unchanged so watch mode does not retrigger on this file.
+                let shouldWrite = true;
+                try {
+                  const existing = await fsp.readFile(outputPath, "utf8");
+                  if (existing === jsonContent) {
+                    shouldWrite = false;
+                  }
+                } catch {
+                  // Missing file: write.
+                }
+
+                if (shouldWrite) {
+                  await fsp.writeFile(outputPath, jsonContent);
+                }
               } catch (fsError) {
                 // Propagate error to Promise.all
                 throw fsError;


### PR DESCRIPTION
# The Issue

### Issue Reference

Fixes: https://github.com/elegantthemes/Divi/issues/49688

### Root Cause

`ConversionOutlineJsonPlugin` runs on every webpack compile and was **always** writing `conversion-outline.json` next to `conversion-outline.ts`. In watch mode (`npm start`), that write touched a file under `src/`, webpack’s watcher treated it as a change, scheduled another compile, and the cycle repeated indefinitely even when no source files had changed.

### Historical Context

No relevant git blame context available for the example plugin webpack plugin behavior.

---

# The Pull Request

### Solution Approach

Before writing `conversion-outline.json`, read the existing file (if any) and **compare the serialized string** to the newly generated JSON. Call `writeFile` only when the file is missing or the content differs, so unchanged builds do not churn the filesystem and watch mode stays idle until real inputs change.

### Screencast Verification

https://github.com/user-attachments/assets/93f89836-c33a-4731-9e06-7aa5b76e6960

### Testing & Verification

#### Quick testing

- From `wp-content/plugins/d5-extension-example-modules`, run `npm start`.
- Confirm webpack compiles once (or after your edits), then **does not** spam “compiled successfully” in a tight loop with no file changes.
- Edit `src/components/d4-module/conversion-outline.ts`, save, and confirm **one** follow-up compile and updated `conversion-outline.json` / copied output under `modules-json/` as expected.

#### Build testing

- Run `npm run build` and confirm it completes successfully and `modules-json` / generated JSON remain correct.

### Alternative solutions (if any)

- **`watchOptions.ignored`** for `modules-json` and/or `**/conversion-outline.json` was considered to mask watcher noise; it was **not** kept here because **skipping unnecessary writes** addresses the root cause without broad ignore rules.

### Changelog

Fixed example extension webpack watch mode repeatedly recompiling because `conversion-outline.json` was rewritten on every build even when its content did not change.