### PR TITLE
Fix :: D5 :: 3PS :: Custom CSS conversion from D4 to D5

### DIFF
--- a/src/components/d4-module/conversion-outline.json
+++ b/src/components/d4-module/conversion-outline.json
@@ -41,6 +41,7 @@
   },
   "css": {
     "after": "css.*.after",
+    "free_form": "css.*.freeForm",
     "before": "css.*.before",
     "main_element": "css.*.mainElement",
     "content": "css.*.content",

--- a/src/components/d4-module/conversion-outline.ts
+++ b/src/components/d4-module/conversion-outline.ts
@@ -45,6 +45,7 @@ export const conversionOutline: ModuleConversionOutline = {
   },
   css: {
     after:         'css.*.after',
+    free_form:     'css.*.freeForm',
     before:        'css.*.before',
     main_element:  'css.*.mainElement',
     content:       'css.*.content',


### PR DESCRIPTION
# The Issue

### Issue Reference
Fixes: https://github.com/elegantthemes/Divi/issues/49271

### Root Cause
Divi 5’s D4→D5 converter only migrates `custom_css_*` attributes that appear under the module’s conversion outline `css` map. The example third-party D4 module outlined `before`, `after`, `main_element`, `content`, and `title`, but never `free_form`, so `custom_css_free_form` was never registered and existing free-form CSS was dropped on conversion. Core modules that declare `free_form` were unaffected; this was an incomplete outline on the example extension, not a gap in core conversion.

### Historical Context
History on the example module’s conversion outline is thin (recent maintenance commits). The important point is that the outline always carried the other custom CSS slots; `free_form` was simply never added when parity with core modules like Blurb was expected.

---

# The Pull Request

### Solution Approach
Add the same `free_form` → `css.*.freeForm` mapping used by core modules so the converter picks up `custom_css_free_form` and routes it through the existing sanitization path. Regenerate the emitted JSON beside the TypeScript source via the plugin’s production build. (`modules-json/` is gitignored in this repo; a local `npm run build` still refreshes that folder for PHP/runtime during development.)

### Screencast Verification

https://github.com/user-attachments/assets/2dd5e7d1-48bb-4d59-a5d8-595dbcb8a777

### Testing & Verification
- Download and Install - [d5-extension-example-modules-v1.0.0.zip](https://github.com/user-attachments/files/27370944/d5-extension-example-modules-v1.0.0.zip)
- D4 layout using the example D4 module: set **Custom CSS → Free-Form** (multi-rule CSS, line breaks), convert to D5.
- Confirm the Free-Form field is populated.

**Note:** Full `npm run build` also updates bundled scripts/styles; for a minimal change set, reviewers may prefer committing only the conversion outline source and `src/.../conversion-outline.json` unless project policy requires shipping updated bundles in the same PR.

### Alternative Solutions (if any)
None tried. Extending Divi core conversion was out of scope; the issue was resolved by aligning the example module outline with the contract core already implements.

### Changelog
Fixed D4 to D5 conversion so free-form custom CSS on the example D4 module migrates into Divi 5 like core modules.
