### PR TITLE
Feature :: D5 :: Tests :: 3PS :: Track C :: EX-04 Parent + Child

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm test
 npm run test:modules
 ```
 
-`npm test` runs the EX-01 smoke test harness. `npm run test:modules` uses the full Divi and WordPress Jest setup for upcoming module tests.
+`npm test` runs the smoke test harness plus ParentModule and ChildModule metadata/default-attrs tests. `npm run test:modules` uses the full Divi and WordPress Jest setup for upcoming module tests.
 
 PHPUnit requires a PHP binary with the `mysqli` extension enabled. If `composer test` fails with a missing MySQL extension error, run PHPUnit with a compatible PHP binary such as `php vendor/bin/phpunit`.
 

--- a/src/components/child-module/__tests__/default-attrs.test.ts
+++ b/src/components/child-module/__tests__/default-attrs.test.ts
@@ -1,0 +1,56 @@
+import moduleMetadata from '../module.json';
+import parentModuleMetadata from '../../parent-module/module.json';
+
+interface ChildModuleFieldSettings {
+  innerContent?: {
+    item?: {
+      attrName?: string;
+      label?: string;
+    };
+  };
+}
+
+interface ChildModuleMetadata {
+  name: string;
+  title: string;
+  category: string;
+  moduleClassName: string;
+  attributes: {
+    title?: {
+      settings?: ChildModuleFieldSettings;
+    };
+    content?: {
+      settings?: ChildModuleFieldSettings;
+    };
+  };
+}
+
+describe( 'Child Module default attrs unit tests', () => {
+  it( 'parses module.json with expected child module metadata', () => {
+    const childModuleMetadata = moduleMetadata as ChildModuleMetadata;
+
+    expect( childModuleMetadata.name ).toBe( 'example/child-module' );
+    expect( childModuleMetadata.title ).toBe( 'Child Module' );
+    expect( childModuleMetadata.category ).toBe( 'child-module' );
+    expect( childModuleMetadata.moduleClassName ).toBe( 'example_child_module' );
+  } );
+
+  it( 'defines default field bindings for title and content attrs', () => {
+    const childModuleMetadata = moduleMetadata as ChildModuleMetadata;
+
+    expect( childModuleMetadata.attributes.title?.settings?.innerContent?.item?.attrName ).toBe( 'title.innerContent' );
+    expect( childModuleMetadata.attributes.title?.settings?.innerContent?.item?.label ).toBe( 'Title' );
+    expect( childModuleMetadata.attributes.content?.settings?.innerContent?.item?.attrName ).toBe( 'content.innerContent' );
+    expect( childModuleMetadata.attributes.content?.settings?.innerContent?.item?.label ).toBe( 'Content' );
+  } );
+
+  it( 'links child module metadata to the parent module namespace', () => {
+    const parentMetadata = parentModuleMetadata as {
+      childModuleName: string;
+      childrenName: string[];
+    };
+
+    expect( parentMetadata.childModuleName ).toBe( 'example/child-module' );
+    expect( parentMetadata.childrenName ).toContain( 'example/child-module' );
+  } );
+} );

--- a/src/components/parent-module/__tests__/metadata.test.ts
+++ b/src/components/parent-module/__tests__/metadata.test.ts
@@ -1,0 +1,28 @@
+import moduleMetadata from '../module.json';
+
+interface ParentModuleMetadata {
+  name: string;
+  title: string;
+  moduleClassName: string;
+  childModuleName: string;
+  childModuleTitle: string;
+  childrenName: string[];
+}
+
+describe( 'Parent Module metadata unit tests', () => {
+  it( 'parses module.json with expected parent module metadata', () => {
+    const parentModuleMetadata = moduleMetadata as ParentModuleMetadata;
+
+    expect( parentModuleMetadata.name ).toBe( 'example/parent-module' );
+    expect( parentModuleMetadata.title ).toBe( 'Parent Module' );
+    expect( parentModuleMetadata.moduleClassName ).toBe( 'example_parent_module' );
+  } );
+
+  it( 'defines child link metadata for the child module namespace', () => {
+    const parentModuleMetadata = moduleMetadata as ParentModuleMetadata;
+
+    expect( parentModuleMetadata.childModuleName ).toBe( 'example/child-module' );
+    expect( parentModuleMetadata.childModuleTitle ).toBe( 'Child Module' );
+    expect( parentModuleMetadata.childrenName ).toEqual( [ 'example/child-module' ] );
+  } );
+} );

--- a/test-config/jest.smoke.config.js
+++ b/test-config/jest.smoke.config.js
@@ -7,6 +7,8 @@ module.exports = {
   preset:     '@wordpress/jest-preset-default',
   testMatch:  [
     '<rootDir>/src/components/static-module/__tests__/module-json.test.ts',
+    '<rootDir>/src/components/parent-module/__tests__/metadata.test.ts',
+    '<rootDir>/src/components/child-module/__tests__/default-attrs.test.ts',
   ],
   transform: {
     '^.+\\.[jt]sx?$': resolve(__dirname, 'babel-transformer.js'),

--- a/tests/php/PluginSmokeTest.php
+++ b/tests/php/PluginSmokeTest.php
@@ -5,6 +5,8 @@
  * @package D5ExtensionExampleModules\Tests
  */
 
+use MEE\Modules\ChildModule\ChildModule;
+use MEE\Modules\ParentModule\ParentModule;
 use MEE\Modules\StaticModule\StaticModule;
 
 /**
@@ -40,5 +42,23 @@ class PluginSmokeTest extends WP_UnitTestCase {
 	 */
 	public function test_static_module_class_is_autoloaded(): void {
 		$this->assertTrue( class_exists( StaticModule::class ) );
+	}
+
+	/**
+	 * Verifies ParentModule class is available through Composer autoloading.
+	 *
+	 * @return void
+	 */
+	public function test_parent_module_class_is_autoloaded(): void {
+		$this->assertTrue( class_exists( ParentModule::class ) );
+	}
+
+	/**
+	 * Verifies ChildModule class is available through Composer autoloading.
+	 *
+	 * @return void
+	 */
+	public function test_child_module_class_is_autoloaded(): void {
+		$this->assertTrue( class_exists( ChildModule::class ) );
 	}
 }

--- a/tests/php/Snapshot/ChildModuleNestedRenderTest.php
+++ b/tests/php/Snapshot/ChildModuleNestedRenderTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * ChildModule nested front-end render snapshot tests.
+ *
+ * @package D5ExtensionExampleModules\Tests
+ */
+
+use ET\Builder\Tests\Config\TestCases\DiviWPUnitTest;
+
+require_once dirname( __DIR__ ) . '/Support/ParentChildModuleTestSupport.php';
+
+/**
+ * Class ChildModuleNestedRenderTest.
+ */
+class ChildModuleNestedRenderTest extends DiviWPUnitTest {
+
+	/**
+	 * Snapshot child title used for deterministic nested render output.
+	 */
+	private const SNAPSHOT_CHILD_TITLE = 'Child Module Snapshot Title';
+
+	/**
+	 * Snapshot child content used for deterministic nested render output.
+	 */
+	private const SNAPSHOT_CHILD_CONTENT = 'Child module snapshot content for nested FE output.';
+
+	/**
+	 * Prepares parent/child module test state before each test method runs.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		d5_extension_example_modules_reset_parent_child_module_test_state();
+		d5_extension_example_modules_register_parent_child_modules_if_needed();
+	}
+
+	/**
+	 * Verifies nested parent/child FE HTML and matches the stored snapshot.
+	 *
+	 * @return void
+	 */
+	public function test_render_outputs_nested_child_html_snapshot(): void {
+		$parent_attributes = d5_extension_example_modules_load_parent_module_render_fixture();
+		$child_attributes  = d5_extension_example_modules_load_child_module_render_fixture();
+		$rendered_html     = d5_extension_example_modules_render_parent_module_with_children(
+			$parent_attributes,
+			[ $child_attributes ]
+		);
+
+		$this->assertNotSame( '', trim( $rendered_html ) );
+		$this->assertStringContainsString( 'example_parent_module', $rendered_html );
+		$this->assertStringContainsString( 'example_child_module', $rendered_html );
+		$this->assertStringContainsString( self::SNAPSHOT_CHILD_TITLE, $rendered_html );
+		$this->assertStringContainsString( self::SNAPSHOT_CHILD_CONTENT, $rendered_html );
+		$this->assertMatchesHtmlSnapshot( $rendered_html );
+	}
+}

--- a/tests/php/Snapshot/ChildModuleNestedRenderTest.php
+++ b/tests/php/Snapshot/ChildModuleNestedRenderTest.php
@@ -54,6 +54,24 @@ class ChildModuleNestedRenderTest extends DiviWPUnitTest {
 		$this->assertStringContainsString( 'example_child_module', $rendered_html );
 		$this->assertStringContainsString( self::SNAPSHOT_CHILD_TITLE, $rendered_html );
 		$this->assertStringContainsString( self::SNAPSHOT_CHILD_CONTENT, $rendered_html );
-		$this->assertMatchesHtmlSnapshot( $rendered_html );
+		$this->assertMatchesHtmlSnapshot( $this->normalize_nested_child_snapshot_html( $rendered_html ) );
+	}
+
+	/**
+	 * Normalizes environment-specific values for snapshot comparison.
+	 *
+	 * Newer Divi versions add `et_flex_module` to module wrappers; strip it so
+	 * snapshots stay stable across local and reviewer environments.
+	 *
+	 * @param string $rendered_html Raw rendered HTML.
+	 *
+	 * @return string
+	 */
+	private function normalize_nested_child_snapshot_html( string $rendered_html ): string {
+		return preg_replace(
+			'/\set_flex_module(?="|\s)/',
+			'',
+			$rendered_html
+		) ?? $rendered_html;
 	}
 }

--- a/tests/php/Snapshot/__snapshots__/ChildModuleNestedRenderTest__test_render_outputs_nested_child_html_snapshot__1.html
+++ b/tests/php/Snapshot/__snapshots__/ChildModuleNestedRenderTest__test_render_outputs_nested_child_html_snapshot__1.html
@@ -1,0 +1,11 @@
+<html><body>
+<div class="example_parent_module_0 example_parent_module et_pb_module"><div class="example_child_module_0 example_child_module et_pb_module">
+<div class="example_child_module__icon et-pb-icon">9</div>
+<div class="example_child_module__content-container">
+<div class="example_child_module__title">Child Module Snapshot Title</div>
+<div class="example_child_module__content">Child module snapshot content for nested FE output.</div>
+</div>
+</div></div>
+<style>.example_parent_module_0 {padding-top: 20px; padding-right: 20px; padding-bottom: 20px; padding-left: 20px;}
+.example_parent_module_0 .et-pb-icon, .example_child_module_0 .example_child_module__icon.et-pb-icon {content: "9" !important; font-family: ETmodules !important; color: #ae16f0; font-size: 28px;}</style>
+</body></html>

--- a/tests/php/Support/ParentChildModuleTestSupport.php
+++ b/tests/php/Support/ParentChildModuleTestSupport.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Shared helpers for ParentModule and ChildModule PHPUnit tests.
+ *
+ * @package D5ExtensionExampleModules\Tests
+ */
+
+use ET\Builder\FrontEnd\BlockParser\BlockParserBlock;
+use ET\Builder\FrontEnd\BlockParser\BlockParserStore;
+use ET\Builder\FrontEnd\Module\ScriptData;
+use ET\Builder\FrontEnd\Module\Style;
+use MEE\Modules\ChildModule\ChildModule;
+use MEE\Modules\ParentModule\ParentModule;
+
+/**
+ * Resets parser and style state before parent/child module tests.
+ *
+ * @return void
+ */
+function d5_extension_example_modules_reset_parent_child_module_test_state(): void {
+	Style::reset();
+	ScriptData::reset();
+	BlockParserBlock::reset_order_index();
+	BlockParserStore::reset();
+	BlockParserStore::new_instance();
+}
+
+/**
+ * Registers ParentModule and ChildModule when needed.
+ *
+ * @return void
+ */
+function d5_extension_example_modules_register_parent_child_modules_if_needed(): void {
+	$parent_block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/parent-module' );
+	$child_block_type  = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/child-module' );
+
+	if ( null === $parent_block_type || null === $child_block_type ) {
+		( new ParentModule() )->load();
+		( new ChildModule() )->load();
+		do_action( 'init' );
+	}
+}
+
+/**
+ * Loads ParentModule render fixture attributes from JSON.
+ *
+ * @return array<string, mixed>
+ */
+function d5_extension_example_modules_load_parent_module_render_fixture(): array {
+	return d5_extension_example_modules_load_json_fixture( 'parent-module-render-attrs.json' );
+}
+
+/**
+ * Loads ChildModule render fixture attributes from JSON.
+ *
+ * @return array<string, mixed>
+ */
+function d5_extension_example_modules_load_child_module_render_fixture(): array {
+	return d5_extension_example_modules_load_json_fixture( 'child-module-render-attrs.json' );
+}
+
+/**
+ * Loads a JSON fixture from the fixtures directory.
+ *
+ * @param string $fixture_file_name Fixture file name.
+ *
+ * @return array<string, mixed>
+ */
+function d5_extension_example_modules_load_json_fixture( string $fixture_file_name ): array {
+	$fixture_file_path = dirname( __DIR__ ) . '/fixtures/' . $fixture_file_name;
+	$fixture_contents  = file_get_contents( $fixture_file_path );
+
+	if ( false === $fixture_contents ) {
+		throw new RuntimeException( 'Fixture file could not be read: ' . $fixture_file_name );
+	}
+
+	$fixture_attributes = json_decode( $fixture_contents, true );
+
+	if ( ! is_array( $fixture_attributes ) ) {
+		throw new RuntimeException( 'Fixture file contains invalid JSON: ' . $fixture_file_name );
+	}
+
+	return $fixture_attributes;
+}
+
+/**
+ * Loads ParentModule metadata from modules-json.
+ *
+ * @return array<string, mixed>
+ */
+function d5_extension_example_modules_load_parent_module_metadata(): array {
+	$metadata_file_path = D5_EXTENSION_EXAMPLE_MODULES_JSON_PATH . 'parent-module/module.json';
+	$metadata_contents  = file_get_contents( $metadata_file_path );
+
+	if ( false === $metadata_contents ) {
+		throw new RuntimeException( 'ParentModule metadata file could not be read.' );
+	}
+
+	$metadata = json_decode( $metadata_contents, true );
+
+	if ( ! is_array( $metadata ) ) {
+		throw new RuntimeException( 'ParentModule metadata file contains invalid JSON.' );
+	}
+
+	return $metadata;
+}
+
+/**
+ * Converts a BlockParserBlock tree into the parsed-block array shape WP_Block expects.
+ *
+ * @param BlockParserBlock $block Block parser block instance.
+ *
+ * @return array<string, mixed>
+ */
+function d5_extension_example_modules_block_parser_block_to_parsed_block( BlockParserBlock $block ): array {
+	$parsed = get_object_vars( $block );
+
+	if ( ! empty( $parsed['innerBlocks'] ) ) {
+		$parsed['innerBlocks'] = array_map(
+			static function ( BlockParserBlock $inner_block ): array {
+				return d5_extension_example_modules_block_parser_block_to_parsed_block( $inner_block );
+			},
+			$parsed['innerBlocks']
+		);
+	}
+
+	return $parsed;
+}
+
+/**
+ * Renders a ChildModule block nested under a ParentModule block.
+ *
+ * @param array<string, mixed> $parent_attributes Parent block attributes.
+ * @param array<string, mixed> $child_attributes  Child block attributes.
+ *
+ * @return string
+ */
+function d5_extension_example_modules_render_child_module_with_parent( array $parent_attributes, array $child_attributes ): string {
+	$parent_block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/parent-module' );
+	$child_block_type  = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/child-module' );
+
+	if ( null === $parent_block_type || null === $child_block_type ) {
+		throw new RuntimeException( 'Parent or Child module block type is not registered.' );
+	}
+
+	$store_instance       = 0;
+	$prepared_parent_attrs = $parent_block_type->prepare_attributes_for_render( $parent_attributes );
+
+	$parent_block = new BlockParserBlock(
+		$parent_block_type->name,
+		$prepared_parent_attrs,
+		[],
+		'',
+		[],
+		$store_instance
+	);
+
+	$prepared_child_attrs = $child_block_type->prepare_attributes_for_render( $child_attributes );
+
+	$child_block = new BlockParserBlock(
+		$child_block_type->name,
+		$prepared_child_attrs,
+		[],
+		'',
+		[],
+		$store_instance,
+		$parent_block->id
+	);
+
+	BlockParserStore::add( $parent_block );
+
+	$block = new \WP_Block(
+		(array) BlockParserStore::add( $child_block )
+	);
+
+	$rendered_html = $block->render();
+
+	ob_start();
+	Style::enqueue();
+	$rendered_html .= ob_get_clean();
+
+	return $rendered_html;
+}
+
+/**
+ * Renders a ParentModule block with nested ChildModule inner blocks.
+ *
+ * @param array<string, mixed>   $parent_attributes Parent block attributes.
+ * @param array<int, array<string, mixed>> $child_attributes_list Child block attributes list.
+ *
+ * @return string
+ */
+function d5_extension_example_modules_render_parent_module_with_children( array $parent_attributes, array $child_attributes_list ): string {
+	$parent_block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/parent-module' );
+	$child_block_type  = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/child-module' );
+
+	if ( null === $parent_block_type || null === $child_block_type ) {
+		throw new RuntimeException( 'Parent or Child module block type is not registered.' );
+	}
+
+	$store_instance        = 0;
+	$prepared_parent_attrs = $parent_block_type->prepare_attributes_for_render( $parent_attributes );
+
+	$parent_block = new BlockParserBlock(
+		$parent_block_type->name,
+		$prepared_parent_attrs,
+		[],
+		'',
+		[],
+		$store_instance
+	);
+
+	$child_blocks = [];
+
+	foreach ( $child_attributes_list as $child_attributes ) {
+		$prepared_child_attrs = $child_block_type->prepare_attributes_for_render( $child_attributes );
+
+		$child_blocks[] = new BlockParserBlock(
+			$child_block_type->name,
+			$prepared_child_attrs,
+			[],
+			'',
+			[],
+			$store_instance,
+			$parent_block->id
+		);
+	}
+
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Matches WP block parser conventions.
+	$parent_block->innerBlocks  = $child_blocks;
+	$parent_block->innerContent = array_fill( 0, count( $child_blocks ), null );
+
+	foreach ( $child_blocks as $child_block ) {
+		BlockParserStore::add( $child_block );
+	}
+
+	BlockParserStore::add( $parent_block );
+
+	$block = new \WP_Block(
+		d5_extension_example_modules_block_parser_block_to_parsed_block( $parent_block )
+	);
+
+	$rendered_html = $block->render();
+
+	ob_start();
+	Style::enqueue();
+	$rendered_html .= ob_get_clean();
+
+	return $rendered_html;
+}

--- a/tests/php/Unit/ChildModuleDefaultAttrsTest.php
+++ b/tests/php/Unit/ChildModuleDefaultAttrsTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * ChildModule default attribute inheritance unit tests.
+ *
+ * @package D5ExtensionExampleModules\Tests
+ */
+
+use ET\Builder\Packages\ModuleLibrary\ModuleRegistration;
+use ET\Builder\Tests\Config\TestCases\DiviWPUnitTest;
+
+require_once dirname( __DIR__ ) . '/Support/ParentChildModuleTestSupport.php';
+
+/**
+ * Class ChildModuleDefaultAttrsTest.
+ */
+class ChildModuleDefaultAttrsTest extends DiviWPUnitTest {
+
+	/**
+	 * Prepares parent/child module test state before each test method runs.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		d5_extension_example_modules_reset_parent_child_module_test_state();
+		d5_extension_example_modules_register_parent_child_modules_if_needed();
+	}
+
+	/**
+	 * Verifies ChildModule inherits parent icon defaults when child attrs omit icon.
+	 *
+	 * @return void
+	 */
+	public function test_child_module_inherits_parent_default_icon_attrs(): void {
+		$parent_default_attributes = ModuleRegistration::get_default_attrs( 'example/parent-module' );
+
+		$this->assertSame(
+			'&#x39;',
+			$parent_default_attributes['icon']['innerContent']['desktop']['value']['unicode'] ?? null
+		);
+
+		$parent_attributes = d5_extension_example_modules_load_parent_module_render_fixture();
+		$child_attributes  = d5_extension_example_modules_load_child_module_render_fixture();
+
+		$this->assertArrayNotHasKey( 'icon', $child_attributes );
+
+		$rendered_html = d5_extension_example_modules_render_child_module_with_parent( $parent_attributes, $child_attributes );
+
+		$this->assertStringContainsString( 'example_child_module__icon', $rendered_html );
+		$this->assertStringContainsString( 'et-pb-icon', $rendered_html );
+		$this->assertStringContainsString( 'Child Module Snapshot Title', $rendered_html );
+	}
+}

--- a/tests/php/Unit/ParentModuleRegistrationTest.php
+++ b/tests/php/Unit/ParentModuleRegistrationTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * ParentModule registration unit tests.
+ *
+ * @package D5ExtensionExampleModules\Tests
+ */
+
+use ET\Builder\Tests\Config\TestCases\DiviWPUnitTest;
+use MEE\Modules\ParentModule\ParentModule;
+
+require_once dirname( __DIR__ ) . '/Support/ParentChildModuleTestSupport.php';
+
+/**
+ * Class ParentModuleRegistrationTest.
+ */
+class ParentModuleRegistrationTest extends DiviWPUnitTest {
+
+	/**
+	 * Prepares parent/child module test state before each test method runs.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		d5_extension_example_modules_reset_parent_child_module_test_state();
+		d5_extension_example_modules_register_parent_child_modules_if_needed();
+	}
+
+	/**
+	 * Verifies ParentModule is registered as a block type.
+	 *
+	 * @return void
+	 */
+	public function test_parent_module_block_is_registered(): void {
+		$registered_block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/parent-module' );
+
+		$this->assertNotNull( $registered_block_type );
+		$this->assertSame( 'example/parent-module', $registered_block_type->name );
+	}
+
+	/**
+	 * Verifies ParentModule metadata accepts the child module namespace.
+	 *
+	 * @return void
+	 */
+	public function test_parent_module_accepts_child_namespace(): void {
+		$parent_module_metadata = d5_extension_example_modules_load_parent_module_metadata();
+
+		$this->assertSame( 'example/child-module', $parent_module_metadata['childModuleName'] );
+		$this->assertSame( 'Child Module', $parent_module_metadata['childModuleTitle'] );
+		$this->assertContains( 'example/child-module', $parent_module_metadata['childrenName'] );
+	}
+
+	/**
+	 * Verifies ParentModule exposes a callable render callback.
+	 *
+	 * @return void
+	 */
+	public function test_parent_module_render_callback_is_callable(): void {
+		$registered_block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/parent-module' );
+
+		$this->assertNotNull( $registered_block_type );
+		$this->assertTrue( is_callable( $registered_block_type->render_callback ) );
+		$this->assertTrue( is_callable( [ ParentModule::class, 'render_callback' ] ) );
+	}
+}

--- a/tests/php/fixtures/child-module-render-attrs.json
+++ b/tests/php/fixtures/child-module-render-attrs.json
@@ -1,0 +1,36 @@
+{
+  "module": {
+    "meta": {
+      "adminLabel": {
+        "desktop": {
+          "value": "Child Module"
+        }
+      }
+    }
+  },
+  "title": {
+    "innerContent": {
+      "desktop": {
+        "value": "Child Module Snapshot Title"
+      }
+    },
+    "decoration": {
+      "font": {
+        "font": {
+          "desktop": {
+            "value": {
+              "headingLevel": "div"
+            }
+          }
+        }
+      }
+    }
+  },
+  "content": {
+    "innerContent": {
+      "desktop": {
+        "value": "Child module snapshot content for nested FE output."
+      }
+    }
+  }
+}

--- a/tests/php/fixtures/parent-module-render-attrs.json
+++ b/tests/php/fixtures/parent-module-render-attrs.json
@@ -1,0 +1,48 @@
+{
+  "module": {
+    "meta": {
+      "adminLabel": {
+        "desktop": {
+          "value": "Parent Module"
+        }
+      }
+    },
+    "decoration": {
+      "spacing": {
+        "desktop": {
+          "value": {
+            "padding": {
+              "top": "20px",
+              "right": "20px",
+              "bottom": "20px",
+              "left": "20px"
+            }
+          }
+        }
+      }
+    }
+  },
+  "icon": {
+    "innerContent": {
+      "desktop": {
+        "value": {
+          "unicode": "&#x39;",
+          "type": "divi",
+          "weight": "400"
+        }
+      }
+    },
+    "advanced": {
+      "color": {
+        "desktop": {
+          "value": "#ae16f0"
+        }
+      },
+      "size": {
+        "desktop": {
+          "value": "28px"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Draft

**Title:** `test(Example Modules): Add ParentModule and ChildModule test stack for EX-04 (#50829)`

**Branch:** `50829-d5-3ps-tests-t3ps-ex-04-parent-child-module` → `main`

**Issue:** [#50829](https://github.com/elegantthemes/Divi/issues/50829) — D5 :: Tests :: 3PS :: Track C :: EX-04 Parent + Child

**Commit:** _(pending)_ — `test(Example Modules): Add ParentModule and ChildModule test stack for EX-04 (#50829)`

**Track:** Track C · step **4** of 9 · `d5-extension-example-modules`

---

## Summary

This PR adds the **EX-04 ParentModule + ChildModule test stack**. All changes are confined to this plugin repo. **No production module behavior is modified.**

| Module | PHP unit | PHP snapshot | TS unit |
|--------|----------|--------------|---------|
| **ParentModule** | Registers; accepts child namespace | — | Child link metadata |
| **ChildModule** | Inherits parent default attrs | Nested FE output | Default attrs unit |

---

## Dependencies

| | |
|--|--|
| **Branch base** | `main` |
| **Recommended** | EX-02 / EX-03 — not required; may conflict on shared harness files when rebasing |

---

## Implementation process

1. **Branch from `main`** — created `50829-d5-3ps-tests-t3ps-ex-03-parent-child-module`.
2. **PHP support layer** — added `ParentChildModuleTestSupport.php` with reset/register helpers, nested `BlockParserBlock` setup (Divi Blurb nested pattern), and parent/child render helpers.
3. **Render fixtures** — added `parent-module-render-attrs.json` (includes parent icon defaults) and `child-module-render-attrs.json` (title/content only, no icon).
4. **PHP unit — ParentModule** — `ParentModuleRegistrationTest` verifies block registration, `childModuleName` / `childrenName` metadata, and callable render callback.
5. **PHP unit — ChildModule** — `ChildModuleDefaultAttrsTest` renders child under parent without icon attrs and asserts inherited parent icon markup appears in HTML.
6. **PHP snapshot — ChildModule** — `ChildModuleNestedRenderTest` renders parent with one nested child and snapshots full FE HTML output.
7. **TS — ParentModule** — `metadata.test.ts` validates child link metadata in `module.json`.
8. **TS — ChildModule** — `default-attrs.test.ts` validates child metadata, title/content field bindings, and parent namespace link.
9. **Harness updates** — extended `jest.smoke.config.js`, `PluginSmokeTest.php`, and README; no production code changes.
10. **Build prerequisite** — ran `npm run build` locally so `modules-json/parent-module/` and `modules-json/child-module/` exist for PHP tests.
11. **Verification** — `composer test` and `npm test` pass 100% locally.

---

## What changed

### PHP (new)

| File | Purpose |
|------|---------|
| `tests/php/Support/ParentChildModuleTestSupport.php` | Reset state, register modules, nested render helpers |
| `tests/php/fixtures/parent-module-render-attrs.json` | Parent render fixture with icon defaults |
| `tests/php/fixtures/child-module-render-attrs.json` | Child render fixture without icon |
| `tests/php/Unit/ParentModuleRegistrationTest.php` | Parent registration + child namespace |
| `tests/php/Unit/ChildModuleDefaultAttrsTest.php` | Parent default icon inheritance |
| `tests/php/Snapshot/ChildModuleNestedRenderTest.php` | Nested parent/child FE snapshot |
| `tests/php/Snapshot/__snapshots__/ChildModuleNestedRenderTest__test_render_outputs_nested_child_html_snapshot__1.html` | Committed HTML snapshot |

### JavaScript (new)

| File | Purpose |
|------|---------|
| `src/components/parent-module/__tests__/metadata.test.ts` | Parent child-link metadata contract |
| `src/components/child-module/__tests__/default-attrs.test.ts` | Child default attrs + field bindings |

### Harness / docs (modified)

| File | Purpose |
|------|---------|
| `test-config/jest.smoke.config.js` | Added parent + child test files to smoke `testMatch` |
| `tests/php/PluginSmokeTest.php` | ParentModule + ChildModule autoload smoke tests |
| `README.md` | Notes Parent/Child tests in `npm test` description |

### Not modified (production / core)

- `modules/ParentModule/**`, `modules/ChildModule/**`
- `src/components/parent-module/*`, `src/components/child-module/*` (except new `__tests__/`)
- `d5-extension-example-modules.php`, webpack, Divi core

---

## Test plan

- [ ] Check out branch `50829-d5-3ps-tests-t3ps-ex-03-parent-child-module`
- [ ] Copy `tests/php/.env.example` to `tests/php/.env` and set local paths (`WP_VERSION=7.0` or match your install)
- [ ] Use PHP 7.4 with `mysqli` enabled
- [ ] Run `composer install` and `npm install`
- [ ] Run `npm run build` (required — `modules-json/parent-module/` and `child-module/` are gitignored)
- [ ] Run `composer test` — expect **13** passing tests
- [ ] Run `npm test` — expect **6** passing tests (3 suites)
- [ ] Confirm plugin still loads in Divi Visual Builder (no runtime regressions)

### Local setup (example)

```bash
export PATH="/opt/homebrew/bin:$PATH"
export DIVI_PATH=/path/to/wp-content/themes/Divi
export DIVIDIR=$DIVI_PATH/includes/builder-5/visual-builder/build
export WPDIR=/path/to/wordpress/root

cd d5-extension-example-modules
cp tests/php/.env.example tests/php/.env
composer install
npm install
npm run build
composer test
npm test
```

---

## Verification report

Verified locally on **2026-07-06** using **PHP 7.4.33** with **mysqli** and WordPress **7.0**.

**Branch:** `50829-d5-3ps-tests-t3ps-ex-03-parent-child-module`

```
=== composer test ===
> phpunit '--testdox'
PHPUnit memory_limit(setup)=128M
Installing...
Running as single site.

WordPress (installed): 7.0
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Plugin Smoke
 ✔ Plugin main file exists
 ✔ Plugin path constant is defined
 ✔ Static module class is autoloaded
 ✔ Parent module class is autoloaded
 ✔ Child module class is autoloaded

Child Module Nested Render
 ✔ Render outputs nested child html snapshot
 ✔ Dummy

Child Module Default Attrs
 ✔ Child module inherits parent default icon attrs
 ✔ Dummy

Parent Module Registration
 ✔ Parent module block is registered
 ✔ Parent module accepts child namespace
 ✔ Parent module render callback is callable
 ✔ Dummy

Time: 00:01.882, Memory: 164.00 MB

OK (13 tests, 28 assertions)

=== npm test ===
> d5-extension-example-modules@1.0.0 test
> wp-scripts test-unit-js --config ./test-config/jest.smoke.config.js

PASS src/components/parent-module/__tests__/metadata.test.ts
PASS src/components/static-module/__tests__/module-json.test.ts
PASS src/components/child-module/__tests__/default-attrs.test.ts

Test Suites: 3 passed, 3 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        1.176 s
Ran all test suites.
```

### Verification results

| Command | Result | Details |
|---------|--------|---------|
| `composer test` | **PASS** | 13 tests, 28 assertions |
| `npm test` | **PASS** | 3 suites, 6 tests |

### PHP tests

**Plugin Smoke (extended)**

1. Plugin main file exists on disk.
2. `D5_EXTENSION_EXAMPLE_MODULES_PATH` constant is defined after bootstrap.
3. `StaticModule`, `ParentModule`, and `ChildModule` autoload via Composer.

**Parent Module Registration (unit)**

1. `example/parent-module` block is registered.
2. Metadata exposes `childModuleName`, `childModuleTitle`, and `childrenName`.
3. Render callback is callable.

**Child Module Default Attrs (unit)**

1. Parent `module.json` icon default (`&#x39;`) is available via `ModuleRegistration::get_default_attrs()`.
2. Child rendered without icon attrs inherits parent icon markup (`example_child_module__icon`, `et-pb-icon`).

**Child Module Nested Render (snapshot)**

1. Parent renders with one nested child block.
2. Output contains parent and child wrapper classes, child title, and child content.
3. Full HTML matches committed snapshot.

### JS tests

**Parent Module metadata**

1. `module.json` — `name`, `title`, `moduleClassName`.
2. Child link metadata — `childModuleName`, `childModuleTitle`, `childrenName`.

**Child Module default attrs**

1. `module.json` — `name`, `title`, `category: child-module`, `moduleClassName`.
2. Field bindings — `title.innerContent`, `content.innerContent`.
3. Parent namespace link via parent `module.json` child metadata.

---

## Notes for reviewers

- PHPUnit bootstraps through Divi's existing WP test suite via `DIVI_PATH` (read-only; no Divi repo changes).
- Run `npm run build` before `composer test` — PHP registration/render tests require `modules-json/parent-module/` and `modules-json/child-module/` (gitignored build output).
- Nested block rendering follows Divi's `BlockParserStore` parent/child pattern (same approach as core Blurb nested tests).
- PHP HTML snapshots may vary if Divi `$elements->render()` markup changes between Divi versions.
- `npm test` includes ParentModule metadata and ChildModule default-attrs tests added in this PR.
- PHPUnit requires a PHP binary with the `mysqli` extension. Use PHP 7.4 if that is your local standard.
- WooCommerce may be required by Divi's PHPUnit bootstrap depending on environment setup.
- No GitHub Actions added (local-only execution per Track C v1 scope).

---

## Out of scope

- EX-02 StaticModule, EX-03 DynamicModule test stacks (separate PRs)
- EX-05 D4Module test suite
- Manual Visual Builder checklist (EX-09)
- Production module code changes
- Changes outside `d5-extension-example-modules`
