### PR TITLE
Feature :: D5 :: Tests :: 3PS :: Track C :: EX-05 D4Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export WPDIR=/absolute/path/to/wordpress/root/folder
 
 For PHP tests, copy `tests/php/.env.example` to `tests/php/.env` and update the database and WordPress paths for your environment. PHPUnit bootstraps through Divi's WP test suite using `DIVI_PATH`. WooCommerce must be installed in your local WordPress plugins directory when using Divi's PHPUnit bootstrap.
 
-Build assets before running JavaScript module tests so Divi Visual Builder packages are available:
+Build assets before running tests:
 
 ```bash
 npm run build:all
@@ -105,7 +105,9 @@ npm test
 npm run test:modules
 ```
 
-`npm test` runs the EX-01 smoke test harness. `npm run test:modules` uses the full Divi and WordPress Jest setup for upcoming module tests.
+`npm run build:all` runs both `npm run build` (D5 `modules-json/` output) and `npm run build:divi-4` (Divi 4 Visual Builder assets). Run `npm run build:divi-4` separately when working on the `divi-4/` subtree only.
+
+`npm test` runs the smoke test harness plus D4Module conversion tests. `npm run test:modules` uses the full Divi and WordPress Jest setup for upcoming module tests.
 
 PHPUnit requires a PHP binary with the `mysqli` extension enabled. If `composer test` fails with a missing MySQL extension error, run PHPUnit with a compatible PHP binary such as `php vendor/bin/phpunit`.
 

--- a/src/components/d4-module/__tests__/conversion.test.ts
+++ b/src/components/d4-module/__tests__/conversion.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import moduleMetadata from '../module.json';
+import { conversionOutline } from '../conversion-outline';
+
+interface D4ModuleMetadata {
+  name: string;
+  d4Shortcode: string;
+  attributes: {
+    title?: {
+      elementType?: string;
+    };
+  };
+}
+
+interface ConversionOutlineJson {
+  module: {
+    content: string;
+    title: string;
+    header_level: string;
+  };
+  css: Record<string, string>;
+  advanced: {
+    fonts: {
+      header: string;
+    };
+  };
+}
+
+describe( 'D4 Module conversion unit tests', () => {
+  it( 'parses module.json with D4 shortcode and heading preview contract', () => {
+    const d4ModuleMetadata = moduleMetadata as D4ModuleMetadata;
+
+    expect( d4ModuleMetadata.name ).toBe( 'example/d4-module' );
+    expect( d4ModuleMetadata.d4Shortcode ).toBe( 'd4_module' );
+    expect( d4ModuleMetadata.attributes.title?.elementType ).toBe( 'heading' );
+  } );
+
+  it( 'matches conversion outline JSON with TypeScript conversion attrs', () => {
+    const conversionOutlineJsonPath = resolve( __dirname, '../conversion-outline.json' );
+    const conversionOutlineJsonContents = readFileSync( conversionOutlineJsonPath, 'utf8' );
+    const conversionOutlineJson = JSON.parse( conversionOutlineJsonContents ) as ConversionOutlineJson;
+
+    expect( conversionOutline.module.content ).toBe( conversionOutlineJson.module.content );
+    expect( conversionOutline.module.title ).toBe( conversionOutlineJson.module.title );
+    expect( conversionOutline.module.header_level ).toBe( conversionOutlineJson.module.header_level );
+    expect( conversionOutline.advanced.fonts.header ).toBe( conversionOutlineJson.advanced.fonts.header );
+    expect( conversionOutline.css.title ).toBe( conversionOutlineJson.css.title );
+    expect( conversionOutline.css.content ).toBe( conversionOutlineJson.css.content );
+  } );
+
+  it( 'maps D4 header level to D5 title decoration attrs', () => {
+    expect( conversionOutline.module.header_level ).toBe( 'title.decoration.font.font.*.headingLevel' );
+    expect( conversionOutline.module.title ).toBe( 'title.innerContent.*' );
+    expect( conversionOutline.module.content ).toBe( 'content.innerContent.*' );
+  } );
+} );

--- a/test-config/jest.smoke.config.js
+++ b/test-config/jest.smoke.config.js
@@ -7,6 +7,7 @@ module.exports = {
   preset:     '@wordpress/jest-preset-default',
   testMatch:  [
     '<rootDir>/src/components/static-module/__tests__/module-json.test.ts',
+    '<rootDir>/src/components/d4-module/__tests__/conversion.test.ts',
   ],
   transform: {
     '^.+\\.[jt]sx?$': resolve(__dirname, 'babel-transformer.js'),

--- a/tests/php/PluginSmokeTest.php
+++ b/tests/php/PluginSmokeTest.php
@@ -5,6 +5,7 @@
  * @package D5ExtensionExampleModules\Tests
  */
 
+use MEE\Modules\D4Module\D4Module;
 use MEE\Modules\StaticModule\StaticModule;
 
 /**
@@ -40,5 +41,14 @@ class PluginSmokeTest extends WP_UnitTestCase {
 	 */
 	public function test_static_module_class_is_autoloaded(): void {
 		$this->assertTrue( class_exists( StaticModule::class ) );
+	}
+
+	/**
+	 * Verifies D4Module class is available through Composer autoloading.
+	 *
+	 * @return void
+	 */
+	public function test_d4_module_class_is_autoloaded(): void {
+		$this->assertTrue( class_exists( D4Module::class ) );
 	}
 }

--- a/tests/php/Snapshot/D4ModuleRenderTest.php
+++ b/tests/php/Snapshot/D4ModuleRenderTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * D4Module front-end render snapshot tests.
+ *
+ * @package D5ExtensionExampleModules\Tests
+ */
+
+use ET\Builder\Tests\Config\TestCases\DiviWPUnitTest;
+
+require_once dirname( __DIR__ ) . '/Support/D4ModuleTestSupport.php';
+
+/**
+ * Class D4ModuleRenderTest.
+ */
+class D4ModuleRenderTest extends DiviWPUnitTest {
+
+	/**
+	 * Snapshot title used for deterministic render output.
+	 */
+	private const SNAPSHOT_TITLE = 'D4 Module Snapshot Title';
+
+	/**
+	 * Snapshot content used for deterministic render output.
+	 */
+	private const SNAPSHOT_CONTENT = 'D4 module snapshot content for FE heading output.';
+
+	/**
+	 * Prepares D4Module render state before each test method runs.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		d5_extension_example_modules_reset_d4_module_test_state();
+		d5_extension_example_modules_register_d4_module_if_needed();
+	}
+
+	/**
+	 * Verifies title renders as a heading and matches the stored snapshot.
+	 *
+	 * @return void
+	 */
+	public function test_render_outputs_heading_html_snapshot(): void {
+		$render_attributes = d5_extension_example_modules_load_d4_module_render_fixture();
+		$rendered_html     = d5_extension_example_modules_render_d4_module( $render_attributes );
+		$normalized_html   = $this->normalize_d4_module_snapshot_html( $rendered_html );
+
+		$this->assertNotSame( '', trim( $rendered_html ) );
+		$this->assertStringContainsString( self::SNAPSHOT_TITLE, $rendered_html );
+		$this->assertStringContainsString( self::SNAPSHOT_CONTENT, $rendered_html );
+		$this->assertStringContainsString( '<h2', $rendered_html );
+		$this->assertStringContainsString( 'example_d4_module_title', $rendered_html );
+		$this->assertStringNotContainsString(
+			'<div class="example_d4_module_title">' . self::SNAPSHOT_TITLE . '</div>',
+			$rendered_html
+		);
+		$this->assertMatchesHtmlSnapshot( $normalized_html );
+	}
+
+	/**
+	 * Normalizes environment-specific values for snapshot comparison.
+	 *
+	 * @param string $rendered_html Raw rendered HTML.
+	 *
+	 * @return string
+	 */
+	private function normalize_d4_module_snapshot_html( string $rendered_html ): string {
+		return preg_replace(
+			'/\set_flex_module(?="|\s)/',
+			'',
+			$rendered_html
+		) ?? $rendered_html;
+	}
+}

--- a/tests/php/Snapshot/__snapshots__/D4ModuleRenderTest__test_render_outputs_heading_html_snapshot__1.html
+++ b/tests/php/Snapshot/__snapshots__/D4ModuleRenderTest__test_render_outputs_heading_html_snapshot__1.html
@@ -1,0 +1,7 @@
+<html><body>
+<div class="example_d4_module_0 example_d4_module et_pb_module"><div class="example_d4_module_inner">
+<h2 class="example_d4_module_title">D4 Module Snapshot Title</h2>
+<div class="example_d4_module_content">D4 module snapshot content for FE heading output.</div>
+</div></div>
+<style>.example_d4_module_0 {padding-top: 20px; padding-right: 20px; padding-bottom: 20px; padding-left: 20px;}</style>
+</body></html>

--- a/tests/php/Support/D4ModuleTestSupport.php
+++ b/tests/php/Support/D4ModuleTestSupport.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Shared helpers for D4Module PHPUnit tests.
+ *
+ * @package D5ExtensionExampleModules\Tests
+ */
+
+use ET\Builder\FrontEnd\BlockParser\BlockParserBlock;
+use ET\Builder\FrontEnd\BlockParser\BlockParserStore;
+use ET\Builder\FrontEnd\Module\ScriptData;
+use ET\Builder\FrontEnd\Module\Style;
+use MEE\Modules\D4Module\D4Module;
+
+/**
+ * Resets parser and style state before D4Module tests.
+ *
+ * @return void
+ */
+function d5_extension_example_modules_reset_d4_module_test_state(): void {
+	Style::reset();
+	ScriptData::reset();
+	BlockParserBlock::reset_order_index();
+	BlockParserStore::reset();
+	BlockParserStore::new_instance();
+}
+
+/**
+ * Registers D4Module when it is not already in the block registry.
+ *
+ * @return void
+ */
+function d5_extension_example_modules_register_d4_module_if_needed(): void {
+	$registered_block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/d4-module' );
+
+	if ( null !== $registered_block_type ) {
+		return;
+	}
+
+	( new D4Module() )->load();
+	do_action( 'init' );
+}
+
+/**
+ * Loads D4Module render fixture attributes from JSON.
+ *
+ * @return array<string, mixed>
+ */
+function d5_extension_example_modules_load_d4_module_render_fixture(): array {
+	$fixture_file_path = dirname( __DIR__ ) . '/fixtures/d4-module-render-attrs.json';
+	$fixture_contents  = file_get_contents( $fixture_file_path );
+
+	if ( false === $fixture_contents ) {
+		throw new RuntimeException( 'D4Module render fixture file could not be read.' );
+	}
+
+	$fixture_attributes = json_decode( $fixture_contents, true );
+
+	if ( ! is_array( $fixture_attributes ) ) {
+		throw new RuntimeException( 'D4Module render fixture file contains invalid JSON.' );
+	}
+
+	return $fixture_attributes;
+}
+
+/**
+ * Loads D4Module metadata from modules-json.
+ *
+ * @return array<string, mixed>
+ */
+function d5_extension_example_modules_load_d4_module_metadata(): array {
+	$metadata_file_path = D5_EXTENSION_EXAMPLE_MODULES_JSON_PATH . 'd4-module/module.json';
+	$metadata_contents  = file_get_contents( $metadata_file_path );
+
+	if ( false === $metadata_contents ) {
+		throw new RuntimeException( 'D4Module metadata file could not be read.' );
+	}
+
+	$metadata = json_decode( $metadata_contents, true );
+
+	if ( ! is_array( $metadata ) ) {
+		throw new RuntimeException( 'D4Module metadata file contains invalid JSON.' );
+	}
+
+	return $metadata;
+}
+
+/**
+ * Loads D4Module conversion outline JSON from modules-json.
+ *
+ * @return array<string, mixed>
+ */
+function d5_extension_example_modules_load_d4_module_conversion_outline(): array {
+	$conversion_outline_file_path = D5_EXTENSION_EXAMPLE_MODULES_JSON_PATH . 'd4-module/conversion-outline.json';
+	$conversion_outline_contents  = file_get_contents( $conversion_outline_file_path );
+
+	if ( false === $conversion_outline_contents ) {
+		throw new RuntimeException( 'D4Module conversion outline file could not be read.' );
+	}
+
+	$conversion_outline = json_decode( $conversion_outline_contents, true );
+
+	if ( ! is_array( $conversion_outline ) ) {
+		throw new RuntimeException( 'D4Module conversion outline file contains invalid JSON.' );
+	}
+
+	return $conversion_outline;
+}
+
+/**
+ * Renders D4Module front-end HTML for the given attributes.
+ *
+ * @param array<string, mixed> $render_attributes Block attributes for render.
+ *
+ * @return string
+ */
+function d5_extension_example_modules_render_d4_module( array $render_attributes ): string {
+	$registered_block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'example/d4-module' );
+
+	if ( null === $registered_block_type ) {
+		throw new RuntimeException( 'D4Module block type is not registered.' );
+	}
+
+	$prepared_attributes = $registered_block_type->prepare_attributes_for_render( $render_attributes );
+
+	$parsed_block = new BlockParserBlock(
+		$registered_block_type->name,
+		$prepared_attributes,
+		[],
+		'',
+		[],
+		0
+	);
+
+	$block = new \WP_Block(
+		(array) BlockParserStore::add( $parsed_block )
+	);
+
+	$rendered_html = $block->render();
+
+	ob_start();
+	Style::enqueue();
+	$rendered_html .= ob_get_clean();
+
+	return $rendered_html;
+}

--- a/tests/php/Unit/D4ModuleConversionOutlineTest.php
+++ b/tests/php/Unit/D4ModuleConversionOutlineTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * D4Module conversion outline and shortcode registration unit tests.
+ *
+ * @package D5ExtensionExampleModules\Tests
+ */
+
+use ET\Builder\Tests\Config\TestCases\DiviWPUnitTest;
+
+require_once dirname( __DIR__ ) . '/Support/D4ModuleTestSupport.php';
+
+/**
+ * Class D4ModuleConversionOutlineTest.
+ */
+class D4ModuleConversionOutlineTest extends DiviWPUnitTest {
+
+	/**
+	 * Prepares D4Module test state before each test method runs.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		d5_extension_example_modules_reset_d4_module_test_state();
+		d5_extension_example_modules_register_d4_module_if_needed();
+	}
+
+	/**
+	 * Verifies the built conversion outline JSON is valid and maps key attrs.
+	 *
+	 * @return void
+	 */
+	public function test_conversion_outline_json_is_valid_and_maps_key_attrs(): void {
+		$conversion_outline = d5_extension_example_modules_load_d4_module_conversion_outline();
+
+		$this->assertArrayHasKey( 'advanced', $conversion_outline );
+		$this->assertArrayHasKey( 'css', $conversion_outline );
+		$this->assertArrayHasKey( 'module', $conversion_outline );
+
+		$this->assertSame( 'title.innerContent.*', $conversion_outline['module']['title'] );
+		$this->assertSame( 'content.innerContent.*', $conversion_outline['module']['content'] );
+		$this->assertSame(
+			'title.decoration.font.font.*.headingLevel',
+			$conversion_outline['module']['header_level']
+		);
+		$this->assertSame( 'title.decoration.font', $conversion_outline['advanced']['fonts']['header'] );
+	}
+
+	/**
+	 * Verifies the D4 shortcode registration path is wired for the module.
+	 *
+	 * @return void
+	 */
+	public function test_d4_shortcode_registration_path_is_wired(): void {
+		$d4_module_metadata = d5_extension_example_modules_load_d4_module_metadata();
+
+		$this->assertSame( 'd4_module', $d4_module_metadata['d4Shortcode'] );
+
+		$divi4_module_file_path = D5_EXTENSION_EXAMPLE_MODULES_PATH . 'divi-4/modules/Divi4Module/Divi4Module.php';
+
+		$this->assertFileExists( $divi4_module_file_path );
+
+		$divi4_module_file_contents = file_get_contents( $divi4_module_file_path );
+
+		$this->assertNotFalse( $divi4_module_file_contents );
+		$this->assertStringContainsString( "public \$slug = 'd4_module';", $divi4_module_file_contents );
+
+		$this->assertNotFalse(
+			has_action( 'et_builder_ready', 'd5_extension_example_module_initialize_d4_modules' )
+		);
+	}
+}

--- a/tests/php/fixtures/d4-module-render-attrs.json
+++ b/tests/php/fixtures/d4-module-render-attrs.json
@@ -1,0 +1,50 @@
+{
+  "module": {
+    "meta": {
+      "adminLabel": {
+        "desktop": {
+          "value": "D4 Module"
+        }
+      }
+    },
+    "decoration": {
+      "spacing": {
+        "desktop": {
+          "value": {
+            "padding": {
+              "top": "20px",
+              "right": "20px",
+              "bottom": "20px",
+              "left": "20px"
+            }
+          }
+        }
+      }
+    }
+  },
+  "title": {
+    "innerContent": {
+      "desktop": {
+        "value": "D4 Module Snapshot Title"
+      }
+    },
+    "decoration": {
+      "font": {
+        "font": {
+          "desktop": {
+            "value": {
+              "headingLevel": "h2"
+            }
+          }
+        }
+      }
+    }
+  },
+  "content": {
+    "innerContent": {
+      "desktop": {
+        "value": "D4 module snapshot content for FE heading output."
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Draft

**Title:** `test(Example Modules): Add D4Module test stack for EX-05 (#50869)`

**Branch:** `50869-d5-3ps-tests-t3ps-ex-05-d4-modules` → `main`

**Issue:** [#50869](https://github.com/elegantthemes/Divi/issues/50869) — D5 :: Tests :: 3PS :: Track C :: EX-05 D4Module

**Commit:** _(pending)_ — `test(Example Modules): Add D4Module test stack for EX-05 (#50869)`

**Track:** Track C · step **5** of 9 · `d5-extension-example-modules`

---

## Summary

This PR adds the **EX-05 D4Module test stack** plus `divi-4/` build gate documentation. All changes are confined to this plugin repo. **No production module behavior is modified.**

| Side | Type | Assert |
|------|------|--------|
| PHP | unit | Conversion outline JSON valid; shortcode registration path |
| PHP | snapshot | FE heading renders as heading (not plain text) |
| TS | unit | Conversion attrs / preview contract |
| Build | L0 | `npm run build:divi-4` included in local test docs |

---

## Dependencies

| | |
|--|--|
| **Branch base** | `main` |
| **Recommended** | EX-02 / EX-03 / EX-04 — not required; may conflict on shared harness files when rebasing |

---

## Implementation process

1. **Branch from `main`** — created `50869-d5-3ps-tests-t3ps-ex-05-d4-modules`.
2. **PHP support layer** — added `D4ModuleTestSupport.php` with reset/register/render helpers and metadata/conversion-outline loaders.
3. **Render fixture** — added `d4-module-render-attrs.json` with title, `headingLevel: h2`, and content text.
4. **PHP unit — conversion + shortcode** — `D4ModuleConversionOutlineTest` validates built `conversion-outline.json` mappings and D4 shortcode wiring (`d4_module` in metadata, Divi4 PHP slug, `et_builder_ready` hook).
5. **PHP snapshot — heading output** — `D4ModuleRenderTest` asserts `<h2 class="example_d4_module_title">` (not plain `<div>` title) and matches HTML snapshot; normalizes `et_flex_module` for cross-Divi stability.
6. **TS conversion unit** — `conversion.test.ts` validates `d4Shortcode`, title `elementType: heading`, and TS/JSON conversion outline parity.
7. **Harness updates** — extended `jest.smoke.config.js`, `PluginSmokeTest.php`, and README with `npm run build:all` / `build:divi-4` prerequisites.
8. **Build gate** — ran `npm run build:all` (D5 `modules-json/` + `divi-4/build/`).
9. **Verification** — `composer test` and `npm test` pass 100% locally.

---

## What changed

### PHP (new)

| File | Purpose |
|------|---------|
| `tests/php/Support/D4ModuleTestSupport.php` | Reset state, register module, render/metadata helpers |
| `tests/php/fixtures/d4-module-render-attrs.json` | Render attrs fixture |
| `tests/php/Unit/D4ModuleConversionOutlineTest.php` | Conversion JSON + D4 shortcode path |
| `tests/php/Snapshot/D4ModuleRenderTest.php` | FE heading snapshot (not plain text) |
| `tests/php/Snapshot/__snapshots__/D4ModuleRenderTest__test_render_outputs_heading_html_snapshot__1.html` | Committed HTML snapshot |

### JavaScript (new)

| File | Purpose |
|------|---------|
| `src/components/d4-module/__tests__/conversion.test.ts` | Conversion attrs + preview contract |

### Harness / docs (modified)

| File | Purpose |
|------|---------|
| `test-config/jest.smoke.config.js` | Added D4Module conversion test to smoke `testMatch` |
| `tests/php/PluginSmokeTest.php` | Added D4Module Composer autoload smoke test |
| `README.md` | Documents `npm run build:all` and `npm run build:divi-4` before tests |

### Not modified (production / core)

- `modules/D4Module/**`
- `src/components/d4-module/*` (except new `__tests__/`)
- `divi-4/**`
- `d5-extension-example-modules.php`, webpack, Divi core

---

## Test plan

- [ ] Check out branch `50869-d5-3ps-tests-t3ps-ex-05-d4-modules`
- [ ] Copy `tests/php/.env.example` to `tests/php/.env` and set local paths (`WP_VERSION=7.0` or match your install)
- [ ] Use PHP 7.4 with `mysqli` enabled
- [ ] Run `composer install` and `npm install`
- [ ] Run `npm run build:all` (required — D5 `modules-json/d4-module/` and `divi-4/build/` are gitignored)
- [ ] Run `composer test` — expect **9** passing tests
- [ ] Run `npm test` — expect **4** passing tests (2 suites)
- [ ] Confirm `npm run build:all` passes (Definition of Done)
- [ ] Confirm plugin still loads in Divi Visual Builder (no runtime regressions)

### Local setup (example)

```bash
export PATH="/opt/homebrew/bin:$PATH"
export DIVI_PATH=/path/to/wp-content/themes/Divi
export DIVIDIR=$DIVI_PATH/includes/builder-5/visual-builder/build
export WPDIR=/path/to/wordpress/root

cd d5-extension-example-modules
cp tests/php/.env.example tests/php/.env
composer install
npm install
npm run build:all
composer test
npm test
```

---

## Verification report

Verified locally on **2026-07-07** using **PHP 7.4.33** with **mysqli** and WordPress **7.0**.

**Branch:** `50869-d5-3ps-tests-t3ps-ex-05-d4-modules`

### Step 1 — `npm run build:all`

```
webpack 5.91.0 compiled successfully (D5 + divi-4)
asset d5-extension-example-modules-divi4.js 1.05 KiB [emitted] [minimized]
```

### Step 2 — `composer test`

```
> phpunit '--testdox'
WordPress (installed): 7.0
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Plugin Smoke
 ✔ Plugin main file exists
 ✔ Plugin path constant is defined
 ✔ Static module class is autoloaded
 ✔ D4 module class is autoloaded

D4Module Render
 ✔ Render outputs heading html snapshot

D4Module Conversion Outline
 ✔ Conversion outline json is valid and maps key attrs
 ✔ D4 shortcode registration path is wired

OK (9 tests, 26 assertions)
Time: 00:01.258, Memory: 162.00 MB

Note: `--testdox` also lists inherited `Dummy` tests from Divi's `DiviWPUnitTest` base class (2 extra rows). PHPUnit's summary above is authoritative — 9 tests, 26 assertions.
```

### Step 3 — `npm test`

```
PASS src/components/d4-module/__tests__/conversion.test.ts
PASS src/components/static-module/__tests__/module-json.test.ts

Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Time:        1.776 s
Ran all test suites.
```

### Verification results

| Command | Result | Details |
|---------|--------|---------|
| `npm run build:all` | **PASS** | D5 + divi-4 webpack builds |
| `composer test` | **PASS** | 9 tests, 26 assertions |
| `npm test` | **PASS** | 2 suites, 4 tests |

### PHP tests

**Plugin Smoke (extended)**

1. Plugin main file exists on disk.
2. `D5_EXTENSION_EXAMPLE_MODULES_PATH` constant is defined after bootstrap.
3. `MEE\Modules\StaticModule\StaticModule` autoloads via Composer.
4. `MEE\Modules\D4Module\D4Module` autoloads via Composer.

**D4Module Conversion Outline (unit)**

1. Built `modules-json/d4-module/conversion-outline.json` parses and maps `title`, `content`, and `header_level`.
2. `module.json` `d4Shortcode` is `d4_module`.
3. `divi-4/modules/Divi4Module/Divi4Module.php` defines `$slug = 'd4_module'`.
4. Plugin registers D4 modules on `et_builder_ready`.

**D4Module Render (snapshot)**

1. Title renders as `<h2 class="example_d4_module_title">` — not a plain `<div>` title.
2. Snapshot content includes title and body text.
3. Normalized HTML matches committed snapshot.

### JS tests

**D4 Module conversion**

1. `module.json` — `d4Shortcode: d4_module`, title `elementType: heading`.
2. `conversion-outline.ts` matches `conversion-outline.json` for module/css/advanced mappings.
3. `header_level` maps to `title.decoration.font.font.*.headingLevel`.

---

## Notes for reviewers

- PHPUnit bootstraps through Divi's existing WP test suite via `DIVI_PATH` (read-only; no Divi repo changes).
- Run `npm run build:all` before `composer test` — PHP tests require `modules-json/d4-module/` (D5 build) and conversion outline JSON copied at build time.
- Snapshot HTML normalizes `et_flex_module` before comparison to reduce Divi version drift across environments.
- `npm test` includes the D4Module conversion test added in this PR.
- PHPUnit requires a PHP binary with the `mysqli` extension. Use PHP 7.4 if that is your local standard.
- WooCommerce may be required by Divi's PHPUnit bootstrap depending on environment setup.
- No GitHub Actions added (local-only execution per Track C v1 scope).

---

## Out of scope

- EX-02 StaticModule, EX-03 DynamicModule, EX-04 Parent+Child test stacks (separate PRs)
- Manual Visual Builder checklist (EX-09)
- Production module code changes
- Changes outside `d5-extension-example-modules`
